### PR TITLE
Fixed detection of clang++ on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,24 @@ add_library(vk-bootstrap src/VkBootstrap.h src/VkBootstrap.cpp)
 add_library(vk-bootstrap::vk-bootstrap ALIAS vk-bootstrap)
 
 add_library(vk-bootstrap-compiler-warnings INTERFACE)
+
+# Determine whether we're compiling with clang++
+string(FIND "${CMAKE_CXX_COMPILER}" "clang++" VK_BOOTSTRAP_COMPILER_CLANGPP)
+if(VK_BOOTSTRAP_COMPILER_CLANGPP GREATER -1)
+  set(VK_BOOTSTRAP_COMPILER_CLANGPP 1)
+else()
+  set(VK_BOOTSTRAP_COMPILER_CLANGPP 0)
+endif()
+
 target_compile_options(vk-bootstrap-compiler-warnings
         INTERFACE
-        $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,$<AND:$<CXX_COMPILER_ID:Clang>,$<NOT:$<STREQUAL:"x${CMAKE_CXX_SIMULATE_ID}","xMSVC">>>>:
+        $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,${VK_BOOTSTRAP_COMPILER_CLANGPP}>:
         -Wall
         -Wextra
         -pedantic-errors
         -Wconversion
         -Wsign-conversion>
-        $<$<OR:$<CXX_COMPILER_ID:MSVC>,$<AND:$<CXX_COMPILER_ID:Clang>,$<STREQUAL:"x${CMAKE_CXX_SIMULATE_ID}","xMSVC">>>:
+        $<$<CXX_COMPILER_ID:MSVC>:
         /WX
         /W4>
         )


### PR DESCRIPTION
I'm using clang++ on windows to compile my project. One of my submodules uses vk-bootstrap which has been updated by the maintainer recently. After updating the submodule the build failed with
```
[1/45] Building CXX object ext/vuk/ext/vk-bootstrap/CMakeFiles/vk-bootstrap.dir/src/VkBootstrap.cpp.obj
FAILED: ext/vuk/ext/vk-bootstrap/CMakeFiles/vk-bootstrap.dir/src/VkBootstrap.cpp.obj
C:\llvm\bin\clang++.exe   -I../ext/vuk/ext/vk-bootstrap/src -IC:/VulkanSDK/1.2.135.0/Include -g -Xclang -gcodeview -O0 -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd   /WX /W4 -std=gnu++2a -MD -MT ext/vuk/ext/vk-bootstrap/CMakeFiles/vk-bootstrap.dir/src/VkBootstrap.cpp.obj -MF ext\vuk\ext\vk-bootstrap\CMakeFiles\vk-bootstrap.dir\src\VkBootstrap.cpp.obj.d -o ext/vuk/ext/vk-bootstrap/CMakeFiles/vk-bootstrap.dir/src/VkBootstrap.cpp.obj -c ../ext/vuk/ext/vk-bootstrap/src/VkBootstrap.cpp
clang++: error: no such file or directory: '/WX'
clang++: error: no such file or directory: '/W4'
```
Apparently clang++ on windows is supposed to define the msvc flags just like clang-cl (https://cmake.org/cmake/help/latest/variable/MSVC.html), which leads to it being incorrectly identified and passed invalid flags.
I have resolved that issue by matching the compiler's path against "clang++", which will always identify that compiler correctly.