### PR TITLE
Dynamically load vulkan instead of statically link.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ target_compile_options(vk-bootstrap-compiler-warnings
 target_include_directories(vk-bootstrap PUBLIC src)
 target_include_directories(vk-bootstrap PUBLIC ${Vulkan_INCLUDE_DIR})
 target_link_libraries(vk-bootstrap
-        PUBLIC ${Vulkan_LIBRARY}
         PRIVATE
         vk-bootstrap-compiler-warnings)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,10 +57,15 @@ auto inst_builder_ret = instance_builder
         .build();
 ```
 
-To query the available layers and extensions, use the `get_system_info()` function of `vkb::InstanceBuilder` to get a `SystemInfo` struct. It contains a `is_layer_available()` and `is_extension_available()` function to check for a layer or extensions before enabling it. It also has booleans for if the validation layers are present and if the VK_EXT_debug_utils extension is available.
+To query the available layers and extensions, get a `SystemInfo` struct from `SystemInfo::get_system_info()`. It contains a `is_layer_available()` and `is_extension_available()` function to check for a layer or extensions before enabling it. It also has booleans for if the validation layers are present and if the VK_EXT_debug_utils extension is available.
 
 ```cpp
-auto system_info = instance_builder.get_system_info();
+auto system_info_ret = vkb::SystemInfo.get_system_info();
+if (!system_info_ret) {
+    printf("%s\n", system_info_ret.error().message());
+    return -1;
+}
+auto system_info = system_info_ret.value();
 if (system_info.is_layer_available("VK_LAYER_LUNARG_api_dump")) {
     instance_builder.enable_layer("VK_LAYER_LUNARG_api_dump");
 }

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -3,7 +3,8 @@ target_link_libraries(vk-bootstrap-triangle
         PRIVATE
         glfw
         vk-bootstrap
-        vk-bootstrap-compiler-warnings)
+        vk-bootstrap-compiler-warnings
+        ${Vulkan_LIBRARY})
 
 add_custom_command(
         TARGET vk-bootstrap-triangle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(vk-bootstrap-test main.cpp bootstrap_tests.cpp error_code_tests.cpp)
 target_link_libraries(vk-bootstrap-test
-        PRIVATE
-        vk-bootstrap
-        vk-bootstrap-compiler-warnings
-        glfw
-        Catch2
-        )
+    PRIVATE
+    vk-bootstrap
+    vk-bootstrap-compiler-warnings
+    glfw
+    Catch2
+)

--- a/tests/common.h
+++ b/tests/common.h
@@ -5,17 +5,27 @@
 #include <memory>
 #include <iostream>
 
+#if defined(_WIN32)
+#include <fcntl.h>
+#define NOMINMAX
+#include <windows.h>
+#endif // _WIN32
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <dlfcn.h>
+#endif
+
 #define GLFW_INCLUDE_VULKAN
 #include "GLFW/glfw3.h"
 
 #include "../src/VkBootstrap.h"
 
-GLFWwindow* create_window_glfw (const char * window_name = "", bool resize = true) {
+GLFWwindow* create_window_glfw (const char* window_name = "", bool resize = true) {
 	glfwInit ();
 	glfwWindowHint (GLFW_CLIENT_API, GLFW_NO_API);
 	if (!resize) glfwWindowHint (GLFW_RESIZABLE, GLFW_FALSE);
 
-	return glfwCreateWindow (1024,1024, window_name, NULL, NULL);
+	return glfwCreateWindow (1024, 1024, window_name, NULL, NULL);
 }
 void destroy_window_glfw (GLFWwindow* window) {
 	glfwDestroyWindow (window);
@@ -36,6 +46,44 @@ VkSurfaceKHR create_surface_glfw (VkInstance instance, GLFWwindow* window) {
 	}
 	return surface;
 }
-void destroy_surface (VkInstance instance, VkSurfaceKHR surface) {
-	vkDestroySurfaceKHR (instance, surface, nullptr);
-}
+
+struct VulkanLibrary {
+#if defined(__linux__) || defined(__APPLE__)
+	void* library;
+#elif defined(_WIN32)
+
+	HMODULE library;
+#endif
+	PFN_vkGetInstanceProcAddr ptr_vkGetInstanceProcAddr = VK_NULL_HANDLE;
+
+	VulkanLibrary () {
+#if defined(__linux__)
+		library = dlopen ("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+		if (!library) library = dlopen ("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+#elif defined(__APPLE__)
+		library = dlopen ("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
+		if (!library) library = dlopen ("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+#elif defined(_WIN32)
+		library = LoadLibrary (TEXT ("vulkan-1.dll"));
+#else
+		assert (false && "Unsupported platform");
+#endif
+		if (!library) return;
+#if defined(__linux__) || defined(__APPLE__)
+		ptr_vkGetInstanceProcAddr =
+		    reinterpret_cast<PFN_vkGetInstanceProcAddr> (dlsym (library, "vkGetInstanceProcAddr"));
+#elif defined(_WIN32)
+		ptr_vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr> (
+		    GetProcAddress (library, "vkGetInstanceProcAddr"));
+#endif
+	}
+
+	void close () {
+#if defined(__linux__) || defined(__APPLE__)
+		dlclose (library);
+#elif defined(_WIN32)
+		FreeLibrary (library);
+#endif
+		library = 0;
+	}
+};


### PR DESCRIPTION
Make vk-bootstrap capable of loading the vulkan runtime and not need to
link against the library. This improves the usability of vk-bootstrap since
now you don't need the vulkan library on your system to build.

This commit also changes how SystemInfo works so as to allow the dynamic
vulkan loading.

Closes #17 