### PR TITLE
Fixed a typo on README.md about dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See `example/triangle.cpp` for an example that renders a triangle to the screen.
 
 ## Setting up `vk-bootstrap`
 
-This library has no external dependencies beyond C++14, it's standard library, and the Vulkan Headers.
+This library has no external dependencies beyond C++14, its standard library, and the Vulkan Headers.
 
 Note: on Unix platforms, `vk-bootstrap` will require the dynamic linker in order to compile as the library doesn't link against `vulkan-1.dll`/`libvulkan.so` directly. 
 


### PR DESCRIPTION
Changed "it's" to "its" on README.md, under the "Setting up vk-bootstrap" section. I believe it is meant that the library depends on the standard library of C++14, not that it is a standard library itself.