### PR TITLE
Check desired surface formats against feature flags

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1727,7 +1727,7 @@ detail::Result<Swapchain> SwapchainBuilder::build() const {
 		image_count = surface_support.capabilities.maxImageCount;
 	}
 	VkSurfaceFormatKHR surface_format = detail::find_surface_format(
-	    info.physical_device, surface_support.formats, desired_formats, info.image_usage_flags);
+	    info.physical_device, surface_support.formats, desired_formats, info.format_feature_flags);
 
 	VkExtent2D extent =
 	    detail::find_extent(surface_support.capabilities, info.desired_width, info.desired_height);

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1606,7 +1606,7 @@ Result<SurfaceSupportDetails> query_surface_support_details(VkPhysicalDevice phy
 VkSurfaceFormatKHR find_surface_format(VkPhysicalDevice phys_device,
     std::vector<VkSurfaceFormatKHR> const& available_formats,
     std::vector<VkSurfaceFormatKHR> const& desired_formats,
-    VkImageUsageFlags usage_flags) {
+    VkFormatFeatureFlags feature_flags) {
 	for (auto const& desired_format : desired_formats) {
 		for (auto const& available_format : available_formats) {
 			// finds the first format that is desired and available
@@ -1615,7 +1615,7 @@ VkSurfaceFormatKHR find_surface_format(VkPhysicalDevice phys_device,
 				VkFormatProperties properties;
 				detail::vulkan_functions().fp_vkGetPhysicalDeviceFormatProperties(
 				    phys_device, desired_format.format, &properties);
-				if ((properties.optimalTilingFeatures & usage_flags) == usage_flags)
+				if ((properties.optimalTilingFeatures & feature_flags) == feature_flags)
 					return desired_format;
 			}
 		}
@@ -1889,6 +1889,18 @@ SwapchainBuilder& SwapchainBuilder::add_image_usage_flags(VkImageUsageFlags usag
 }
 SwapchainBuilder& SwapchainBuilder::use_default_image_usage_flags() {
 	info.image_usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+	return *this;
+}
+SwapchainBuilder& SwapchainBuilder::set_format_feature_flags(VkFormatFeatureFlags feature_flags) {
+	info.format_feature_flags = feature_flags;
+	return *this;
+}
+SwapchainBuilder& SwapchainBuilder::add_format_feature_flags(VkFormatFeatureFlags feature_flags) {
+	info.format_feature_flags = info.format_feature_flags | feature_flags;
+	return *this;
+}
+SwapchainBuilder& SwapchainBuilder::use_default_format_feature_flags() {
+	info.format_feature_flags = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
 	return *this;
 }
 SwapchainBuilder& SwapchainBuilder::set_image_array_layer_count(uint32_t array_layer_count) {

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -634,6 +634,14 @@ class SwapchainBuilder {
 	// are provided. The default is VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
 	SwapchainBuilder& use_default_image_usage_flags();
 
+	// Set the bitmask of the format feature flag for acquired swapchain images.
+	SwapchainBuilder& set_format_feature_flags(VkFormatFeatureFlags feature_flags);
+	// Add a format feature to the bitmask for acquired swapchain images.
+	SwapchainBuilder& add_format_feature_flags(VkFormatFeatureFlags feature_flags);
+	// Use the default format feature bitmask values. This is the default if no format features
+	// are provided. The default is VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT
+	SwapchainBuilder& use_default_format_feature_flags();
+
 	// Set the number of views in for multiview/stereo surface
 	SwapchainBuilder& set_image_array_layer_count(uint32_t array_layer_count);
 
@@ -676,6 +684,7 @@ class SwapchainBuilder {
 		uint32_t desired_height = 256;
 		uint32_t array_layer_count = 1;
 		VkImageUsageFlags image_usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+		VkFormatFeatureFlags format_feature_flags = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
 		uint32_t graphics_queue_index = 0;
 		uint32_t present_queue_index = 0;
 		VkSurfaceTransformFlagBitsKHR pre_transform = static_cast<VkSurfaceTransformFlagBitsKHR>(0);


### PR DESCRIPTION
This comparison is a simple addition that proves helpful when the developer intends to use swapchain obtained images for cases like storage purposes.