### PR TITLE
Added generic feature polling/enabling.

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1015,9 +1015,12 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
             prev = &extension;
         }
         if(desc.extension_features.size() > 0) {
-            desc.device_features2.pNext = &desc.extension_features[0].structure;
+            desc.device_features2.pNext = desc.extension_features[0].structure;
         }
         detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &desc.device_features2);
+        for(auto& extension : desc.extension_features) {
+			extension.update();
+		}
     }
 #endif
 	return desc;

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -31,6 +31,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <cstdio>
 #include <mutex>
 
 namespace vkb {
@@ -1264,6 +1265,10 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t maj
 	criteria.desired_version = VK_MAKE_VERSION(major, minor, 0);
 	return *this;
 }
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features(VkPhysicalDeviceFeatures const& features) {
+    criteria.required_features = features;
+    return *this;
+}
 #if defined(VK_API_VERSION_1_2)
 // Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
@@ -1435,6 +1440,8 @@ detail::Result<Device> DeviceBuilder::build() const {
 				final_pnext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&features_node));
 			}
 		}
+	} else {
+        printf("User provided VkPhysicalDeviceFeatures2 instance found in pNext chain. All requirements added via 'add_required_extension_features' will be ignored.");
 	}
 
 	if(!user_defined_phys_dev_features_2 && !has_phys_dev_features_2) {
@@ -1457,10 +1464,6 @@ detail::Result<Device> DeviceBuilder::build() const {
 	device_create_info.pQueueCreateInfos = queueCreateInfos.data();
 	device_create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	device_create_info.ppEnabledExtensionNames = extensions.data();
-
-	if(!final_pnext_chain.empty()) {
-        device_create_info.pNext = final_pnext_chain.front();
-	}
 
 	Device device;
 

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -31,7 +31,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <cstdio>
 #include <mutex>
 
 namespace vkb {

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1259,13 +1259,13 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t maj
 #if defined(VK_API_VERSION_1_2)
 // Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
-    VkPhysicalDeviceVulkan11Features& features_11) {
+    VkPhysicalDeviceVulkan11Features features_11) {
 	features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     add_required_extension_features(features_11);
     return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(
-    VkPhysicalDeviceVulkan12Features& features_12) {
+    VkPhysicalDeviceVulkan12Features features_12) {
 	features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
 	add_required_extension_features(features_12);
     return *this;

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -844,7 +844,10 @@ std::vector<const char*> check_device_extension_support(
 }
 
 // clang-format off
-bool supports_features(VkPhysicalDeviceFeatures supported, VkPhysicalDeviceFeatures requested) {
+bool supports_features(VkPhysicalDeviceFeatures supported,
+                       VkPhysicalDeviceFeatures requested,
+                       const std::vector<ExtensionFeatures>& extension_supported,
+                       const std::vector<ExtensionFeatures>& extension_requested) {
     if (requested.robustBufferAccess && !supported.robustBufferAccess) return false;
     if (requested.fullDrawIndexUint32 && !supported.fullDrawIndexUint32) return false;
     if (requested.imageCubeArray && !supported.imageCubeArray) return false;
@@ -900,75 +903,14 @@ bool supports_features(VkPhysicalDeviceFeatures supported, VkPhysicalDeviceFeatu
     if (requested.sparseResidencyAliased && !supported.sparseResidencyAliased) return false;
     if (requested.variableMultisampleRate && !supported.variableMultisampleRate) return false;
     if (requested.inheritedQueries && !supported.inheritedQueries) return false;
-	return true;
-}
-#if defined(VK_API_VERSION_1_2)
-bool supports_features_11(VkPhysicalDeviceVulkan11Features supported, VkPhysicalDeviceVulkan11Features requested){
-    if (requested.storageBuffer16BitAccess && !supported.storageBuffer16BitAccess) return false;
-    if (requested.uniformAndStorageBuffer16BitAccess && !supported.uniformAndStorageBuffer16BitAccess) return false;
-    if (requested.storagePushConstant16 && !supported.storagePushConstant16) return false;
-    if (requested.storageInputOutput16 && !supported.storageInputOutput16) return false;
-    if (requested.multiview && !supported.multiview) return false;
-    if (requested.multiviewGeometryShader && !supported.multiviewGeometryShader) return false;
-    if (requested.multiviewTessellationShader && !supported.multiviewTessellationShader) return false;
-    if (requested.variablePointersStorageBuffer && !supported.variablePointersStorageBuffer) return false;
-    if (requested.variablePointers && !supported.variablePointers) return false;
-    if (requested.protectedMemory && !supported.protectedMemory) return false;
-    if (requested.samplerYcbcrConversion && !supported.samplerYcbcrConversion) return false;
-    if (requested.shaderDrawParameters && !supported.shaderDrawParameters) return false;
+
+    for(auto i = 0; i < extension_requested.size(); ++i) {
+        auto res = extension_requested[i].match(extension_supported[i]);
+        if(!res) return false;
+    }
+
     return true;
 }
-bool supports_features_12(VkPhysicalDeviceVulkan12Features supported, VkPhysicalDeviceVulkan12Features requested){
-    if(requested.samplerMirrorClampToEdge && !supported.samplerMirrorClampToEdge) return false;
-    if(requested.drawIndirectCount && !supported.drawIndirectCount) return false;
-    if(requested.storageBuffer8BitAccess && !supported.storageBuffer8BitAccess) return false;
-    if(requested.uniformAndStorageBuffer8BitAccess && !supported.uniformAndStorageBuffer8BitAccess) return false;
-    if(requested.storagePushConstant8 && !supported.storagePushConstant8) return false;
-    if(requested.shaderBufferInt64Atomics && !supported.shaderBufferInt64Atomics) return false;
-    if(requested.shaderSharedInt64Atomics && !supported.shaderSharedInt64Atomics) return false;
-    if(requested.shaderFloat16 && !supported.shaderFloat16) return false;
-    if(requested.shaderInt8 && !supported.shaderInt8) return false;
-    if(requested.descriptorIndexing && !supported.descriptorIndexing) return false;
-    if(requested.shaderInputAttachmentArrayDynamicIndexing && !supported.shaderInputAttachmentArrayDynamicIndexing) return false;
-    if(requested.shaderUniformTexelBufferArrayDynamicIndexing && !supported.shaderUniformTexelBufferArrayDynamicIndexing) return false;
-    if(requested.shaderStorageTexelBufferArrayDynamicIndexing && !supported.shaderStorageTexelBufferArrayDynamicIndexing) return false;
-    if(requested.shaderUniformBufferArrayNonUniformIndexing && !supported.shaderUniformBufferArrayNonUniformIndexing) return false;
-    if(requested.shaderSampledImageArrayNonUniformIndexing && !supported.shaderSampledImageArrayNonUniformIndexing) return false;
-    if(requested.shaderStorageBufferArrayNonUniformIndexing && !supported.shaderStorageBufferArrayNonUniformIndexing) return false;
-    if(requested.shaderStorageImageArrayNonUniformIndexing && !supported.shaderStorageImageArrayNonUniformIndexing) return false;
-    if(requested.shaderInputAttachmentArrayNonUniformIndexing && !supported.shaderInputAttachmentArrayNonUniformIndexing) return false;
-    if(requested.shaderUniformTexelBufferArrayNonUniformIndexing && !supported.shaderUniformTexelBufferArrayNonUniformIndexing) return false;
-    if(requested.shaderStorageTexelBufferArrayNonUniformIndexing && !supported.shaderStorageTexelBufferArrayNonUniformIndexing) return false;
-    if(requested.descriptorBindingUniformBufferUpdateAfterBind && !supported.descriptorBindingUniformBufferUpdateAfterBind) return false;
-    if(requested.descriptorBindingSampledImageUpdateAfterBind && !supported.descriptorBindingSampledImageUpdateAfterBind) return false;
-    if(requested.descriptorBindingStorageImageUpdateAfterBind && !supported.descriptorBindingStorageImageUpdateAfterBind) return false;
-    if(requested.descriptorBindingStorageBufferUpdateAfterBind && !supported.descriptorBindingStorageBufferUpdateAfterBind) return false;
-    if(requested.descriptorBindingUniformTexelBufferUpdateAfterBind && !supported.descriptorBindingUniformTexelBufferUpdateAfterBind) return false;
-    if(requested.descriptorBindingStorageTexelBufferUpdateAfterBind && !supported.descriptorBindingStorageTexelBufferUpdateAfterBind) return false;
-    if(requested.descriptorBindingUpdateUnusedWhilePending && !supported.descriptorBindingUpdateUnusedWhilePending) return false;
-    if(requested.descriptorBindingPartiallyBound && !supported.descriptorBindingPartiallyBound) return false;
-    if(requested.descriptorBindingVariableDescriptorCount && !supported.descriptorBindingVariableDescriptorCount) return false;
-    if(requested.runtimeDescriptorArray && !supported.runtimeDescriptorArray) return false;
-    if(requested.samplerFilterMinmax && !supported.samplerFilterMinmax) return false;
-    if(requested.scalarBlockLayout && !supported.scalarBlockLayout) return false;
-    if(requested.imagelessFramebuffer && !supported.imagelessFramebuffer) return false;
-    if(requested.uniformBufferStandardLayout && !supported.uniformBufferStandardLayout) return false;
-    if(requested.shaderSubgroupExtendedTypes && !supported.shaderSubgroupExtendedTypes) return false;
-    if(requested.separateDepthStencilLayouts && !supported.separateDepthStencilLayouts) return false;
-    if(requested.hostQueryReset && !supported.hostQueryReset) return false;
-    if(requested.timelineSemaphore && !supported.timelineSemaphore) return false;
-    if(requested.bufferDeviceAddress && !supported.bufferDeviceAddress) return false;
-    if(requested.bufferDeviceAddressCaptureReplay && !supported.bufferDeviceAddressCaptureReplay) return false;
-    if(requested.bufferDeviceAddressMultiDevice && !supported.bufferDeviceAddressMultiDevice) return false;
-    if(requested.vulkanMemoryModel && !supported.vulkanMemoryModel) return false;
-    if(requested.vulkanMemoryModelDeviceScope && !supported.vulkanMemoryModelDeviceScope) return false;
-    if(requested.vulkanMemoryModelAvailabilityVisibilityChains && !supported.vulkanMemoryModelAvailabilityVisibilityChains) return false;
-    if(requested.shaderOutputViewportIndex && !supported.shaderOutputViewportIndex) return false;
-    if(requested.shaderOutputLayer && !supported.shaderOutputLayer) return false;
-    if(requested.subgroupBroadcastDynamicId && !supported.subgroupBroadcastDynamicId) return false;
-    return true;
-}
-#endif
 // clang-format on
 // finds the first queue which supports graphics operations. returns QUEUE_INDEX_MAX_VALUE if none is found
 uint32_t get_graphics_queue_index(std::vector<VkQueueFamilyProperties> const& families) {
@@ -1049,7 +991,8 @@ uint32_t get_present_queue_index(VkPhysicalDevice const phys_device,
 
 
 PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_device_details(
-    uint32_t instance_version, VkPhysicalDevice phys_device) const {
+    uint32_t instance_version, VkPhysicalDevice phys_device,
+    std::vector<ExtensionFeatures> extension_features_as_template) const {
 	PhysicalDeviceSelector::PhysicalDeviceDesc desc{};
 	desc.phys_device = phys_device;
 	auto queue_families = detail::get_vector_noerror<VkQueueFamilyProperties>(
@@ -1062,16 +1005,20 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 
 #if defined(VK_API_VERSION_1_1)
 	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-
-#if defined(VK_API_VERSION_1_2)
-	desc.device_features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
-	desc.device_features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-	desc.device_features2.pNext = &desc.device_features_11;
-	desc.device_features_11.pNext = &desc.device_features_12;
-#endif
-	if (instance_version >= VK_API_VERSION_1_1) {
-		detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &desc.device_features2);
-	}
+    desc.extension_features = extension_features_as_template;
+    if (instance_version >= VK_API_VERSION_1_1) {
+        ExtensionFeatures* prev = nullptr;
+        for(auto& extension : desc.extension_features) {
+            if(prev != nullptr) {
+                prev->structure->pNext = extension.structure;
+            }
+            prev = &extension;
+        }
+        if(desc.extension_features.size() > 0) {
+            desc.device_features2.pNext = &desc.extension_features[0].structure;
+        }
+        detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &desc.device_features2);
+    }
 #endif
 	return desc;
 }
@@ -1112,7 +1059,6 @@ PhysicalDeviceSelector::Suitable PhysicalDeviceSelector::is_device_suitable(Phys
 	if (desired_extensions_supported.size() != criteria.desired_extensions.size())
 		suitable = Suitable::partial;
 
-
 	bool swapChainAdequate = false;
 	if (criteria.defer_surface_initialization) {
 		swapChainAdequate = true;
@@ -1142,20 +1088,9 @@ PhysicalDeviceSelector::Suitable PhysicalDeviceSelector::is_device_suitable(Phys
 			return Suitable::no;
 	}
 
-	bool required_features_supported = detail::supports_features(pd.device_features, criteria.required_features);
+    bool required_features_supported = detail::supports_features(pd.device_features, criteria.required_features,
+                                                                 pd.extension_features, criteria.extension_features);
 	if (!required_features_supported) return Suitable::no;
-
-#if defined(VK_API_VERSION_1_2)
-	if (instance_info.version >= VK_API_VERSION_1_2) {
-		bool required_features_11_supported =
-		    detail::supports_features_11(pd.device_features_11, criteria.required_features_11);
-		if (!required_features_11_supported) return Suitable::no;
-
-		bool required_features_12_supported =
-		    detail::supports_features_12(pd.device_features_12, criteria.required_features_12);
-		if (!required_features_12_supported) return Suitable::no;
-	}
-#endif
 
 	bool has_required_memory = false;
 	bool has_preferred_memory = false;
@@ -1205,7 +1140,9 @@ detail::Result<PhysicalDevice> PhysicalDeviceSelector::select() const {
 
 	std::vector<PhysicalDeviceDesc> phys_device_descriptions;
 	for (auto& phys_device : physical_devices) {
-		phys_device_descriptions.push_back(populate_device_details(instance_info.version, phys_device));
+        phys_device_descriptions.push_back(populate_device_details(instance_info.version,
+                                                                   phys_device,
+                                                                   criteria.extension_features));
 	}
 
 	PhysicalDeviceDesc selected_device{};
@@ -1231,12 +1168,7 @@ detail::Result<PhysicalDevice> PhysicalDeviceSelector::select() const {
 	out_device.physical_device = selected_device.phys_device;
 	out_device.surface = instance_info.surface;
 	out_device.features = criteria.required_features;
-#if defined(VK_API_VERSION_1_2)
-	out_device.features_11 = criteria.required_features_11;
-	out_device.features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
-	out_device.features_12 = criteria.required_features_12;
-	out_device.features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-#endif
+    out_device.extension_features = criteria.extension_features;
 	out_device.properties = selected_device.device_properties;
 	out_device.memory_properties = selected_device.mem_properties;
 	out_device.queue_families = selected_device.queue_families;
@@ -1321,20 +1253,17 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t maj
 	criteria.desired_version = VK_MAKE_VERSION(major, minor, 0);
 	return *this;
 }
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features(VkPhysicalDeviceFeatures const& features) {
-	criteria.required_features = features;
-	return *this;
-}
 #if defined(VK_API_VERSION_1_2)
+// Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
     VkPhysicalDeviceVulkan11Features const& features_11) {
-	criteria.required_features_11 = features_11;
-	return *this;
+    add_required_features(features_11);
+    return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(
     VkPhysicalDeviceVulkan12Features const& features_12) {
-	criteria.required_features_12 = features_12;
-	return *this;
+    add_required_features(features_12);
+    return *this;
 }
 #endif
 PhysicalDeviceSelector& PhysicalDeviceSelector::defer_surface_initialization() {
@@ -1467,63 +1396,40 @@ detail::Result<Device> DeviceBuilder::build() const {
 	if (physical_device.surface != VK_NULL_HANDLE || physical_device.defer_surface_initialization)
 		extensions.push_back({ VK_KHR_SWAPCHAIN_EXTENSION_NAME });
 
-	std::vector<VkBaseOutStructure*> pNext_chain = info.pNext_chain;
+    bool has_phys_dev_features_2 = false;
 
-	// check if certain structs were added in the pNext chain by the user
-	bool has_phys_dev_features_2 = false;
-	bool has_phys_dev_vulkan_features_11 = false;
-	bool has_phys_dev_vulkan_features_12 = false;
-	for (auto& pNext_struct : pNext_chain) {
-		if (pNext_struct->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2) {
-			has_phys_dev_features_2 = true;
-		}
-		if (pNext_struct->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES) {
-			has_phys_dev_vulkan_features_11 = true;
-		}
-		if (pNext_struct->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES) {
-			has_phys_dev_vulkan_features_12 = true;
-		}
-	}
-
-// Add the correct structs to the pNext chain if api is 1.1/1.2 and aren't already present
-// This is to guard against users who were already doing that
+// Setup the pNexts of all the extension features
 #if defined(VK_API_VERSION_1_1)
-	VkPhysicalDeviceFeatures2 local_features2{};
-	if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0) && !has_phys_dev_features_2) {
-		local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-		local_features2.features = physical_device.features;
-		pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&local_features2));
-		has_phys_dev_features_2 = true;
-	}
-#if defined(VK_API_VERSION_1_2)
-	VkPhysicalDeviceVulkan11Features local_features_11 = physical_device.features_11;
-	VkPhysicalDeviceVulkan12Features local_features_12 = physical_device.features_12;
-	if (physical_device.instance_version >= VK_MAKE_VERSION(1, 2, 0)) {
-		if (!has_phys_dev_vulkan_features_11) {
-			pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&local_features_11));
-			has_phys_dev_vulkan_features_11 = true;
-		}
-		if (!has_phys_dev_vulkan_features_12) {
-			pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&local_features_12));
-			has_phys_dev_vulkan_features_12 = true;
-		}
-	}
-#endif
+    VkPhysicalDeviceFeatures2 local_features2{};
+    if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0) &&
+        physical_device.extension_features.size() > 0) {
+        ExtensionFeatures* prev = nullptr;
+        for(auto& extension : physical_device.extension_features) {
+            if(prev != nullptr) {
+                prev->structure->pNext = extension.structure;
+            }
+            prev = &extension;
+        }
+        local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        local_features2.features = physical_device.features;
+        local_features2.pNext = physical_device.extension_features[0].structure;
+        has_phys_dev_features_2 = true;
+    }
 #endif
 
 	VkDeviceCreateInfo device_create_info = {};
 	device_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-	detail::setup_pNext_chain(device_create_info, pNext_chain);
 	device_create_info.flags = info.flags;
 	device_create_info.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
 	device_create_info.pQueueCreateInfos = queueCreateInfos.data();
 	device_create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	device_create_info.ppEnabledExtensionNames = extensions.data();
 	// VUID-VkDeviceCreateInfo-pNext-00373 - don't add pEnabledFeatures if the phys_dev_features_2 is present
-	if (!has_phys_dev_features_2) {
-		device_create_info.pEnabledFeatures = &physical_device.features;
-	}
-
+    if (!has_phys_dev_features_2) {
+        device_create_info.pEnabledFeatures = &physical_device.features;
+    } else {
+        device_create_info.pNext = &local_features2;
+    }
 
 	Device device;
 	VkResult res = detail::vulkan_functions().fp_vkCreateDevice(

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1259,12 +1259,14 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t maj
 #if defined(VK_API_VERSION_1_2)
 // Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
-    VkPhysicalDeviceVulkan11Features const& features_11) {
+    VkPhysicalDeviceVulkan11Features& features_11) {
+	features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     add_required_extension_features(features_11);
     return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(
-    VkPhysicalDeviceVulkan12Features const& features_12) {
+    VkPhysicalDeviceVulkan12Features& features_12) {
+	features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
 	add_required_extension_features(features_12);
     return *this;
 }

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -846,8 +846,8 @@ std::vector<const char*> check_device_extension_support(
 // clang-format off
 bool supports_features(VkPhysicalDeviceFeatures supported,
                        VkPhysicalDeviceFeatures requested,
-                       std::vector<ExtensionFeatures> const& extension_supported,
-                       std::vector<ExtensionFeatures> const& extension_requested) {
+                       std::vector<FeaturesContainer> const& extension_supported,
+                       std::vector<FeaturesContainer> const& extension_requested) {
     if (requested.robustBufferAccess && !supported.robustBufferAccess) return false;
     if (requested.fullDrawIndexUint32 && !supported.fullDrawIndexUint32) return false;
     if (requested.imageCubeArray && !supported.imageCubeArray) return false;
@@ -992,7 +992,7 @@ uint32_t get_present_queue_index(VkPhysicalDevice const phys_device,
 
 PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_device_details(
     uint32_t instance_version, VkPhysicalDevice phys_device,
-    std::vector<detail::ExtensionFeatures> extension_features_as_template) const {
+    std::vector<detail::FeaturesContainer> extension_features_as_template) const {
 	PhysicalDeviceSelector::PhysicalDeviceDesc desc{};
 	desc.phys_device = phys_device;
 	auto queue_families = detail::get_vector_noerror<VkQueueFamilyProperties>(
@@ -1007,15 +1007,15 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     desc.extension_features = extension_features_as_template;
     if (instance_version >= VK_API_VERSION_1_1) {
-		detail::ExtensionFeatures* prev = nullptr;
+		detail::FeaturesContainer* prev = nullptr;
         for(auto& extension : desc.extension_features) {
             if(prev != nullptr) {
-                prev->structure.header->pNext = extension.structure.header;
+                prev->header->pNext = extension.header;
             }
             prev = &extension;
         }
         if(desc.extension_features.size() > 0) {
-            desc.device_features2.pNext = desc.extension_features.front().structure.header;
+            desc.device_features2.pNext = desc.extension_features.front().header;
         }
         detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &desc.device_features2);
     }
@@ -1402,22 +1402,20 @@ detail::Result<Device> DeviceBuilder::build() const {
 
 #if defined(VK_API_VERSION_1_1)
 	// Setup the pNexts of all the extension features
-	std::vector<detail::ExtensionFeatures> match = physical_device.extension_features;
+	std::vector<detail::FeaturesContainer> match = physical_device.extension_features;
     VkPhysicalDeviceFeatures2 local_features2{};
-	//VkBaseOutStructure* tail = nullptr;
     if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0) &&
 		match.size() > 0) {
-		detail::ExtensionFeatures* prev = nullptr;
+		detail::FeaturesContainer* prev = nullptr;
         for(auto& extension : match) {
             if(prev != nullptr) {
-                prev->structure.header->pNext = extension.structure.header;
+                prev->header->pNext = extension.header;
             }
             prev = &extension;
-			//tail = prev->structure;
         }
         local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         local_features2.features = physical_device.features;
-        local_features2.pNext = match.front().structure.header;
+        local_features2.pNext = match.front().header;
         has_phys_dev_features_2 = true;
     }
 #endif
@@ -1437,7 +1435,7 @@ detail::Result<Device> DeviceBuilder::build() const {
     if (has_phys_dev_features_2) {
         device_create_info.pNext = &local_features2;
 		if(info.pNext_chain.size() > 0) {
-			match.back().structure.header->pNext = info.pNext_chain.front();
+			match.back().header->pNext = info.pNext_chain.front();
 		}
     } else {
 		device_create_info.pEnabledFeatures = &physical_device.features;

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -690,6 +690,9 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	VkInstanceCreateInfo instance_create_info = {};
 	instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
 	detail::setup_pNext_chain(instance_create_info, pNext_chain);
+    for(auto& node : pNext_chain) {
+        assert(node->sType != VK_STRUCTURE_TYPE_APPLICATION_INFO);
+    }
 	instance_create_info.flags = info.flags;
 	instance_create_info.pApplicationInfo = &app_info;
 	instance_create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
@@ -846,8 +849,8 @@ std::vector<const char*> check_device_extension_support(
 // clang-format off
 bool supports_features(VkPhysicalDeviceFeatures supported,
                        VkPhysicalDeviceFeatures requested,
-                       std::vector<FeaturesContainer> const& extension_supported,
-                       std::vector<FeaturesContainer> const& extension_requested) {
+                       std::vector<GenericFeaturesPNextNode> const& extension_supported,
+                       std::vector<GenericFeaturesPNextNode> const& extension_requested) {
     if (requested.robustBufferAccess && !supported.robustBufferAccess) return false;
     if (requested.fullDrawIndexUint32 && !supported.fullDrawIndexUint32) return false;
     if (requested.imageCubeArray && !supported.imageCubeArray) return false;
@@ -905,7 +908,8 @@ bool supports_features(VkPhysicalDeviceFeatures supported,
     if (requested.inheritedQueries && !supported.inheritedQueries) return false;
 
     for(auto i = 0; i < extension_requested.size(); ++i) {
-        auto res = extension_requested[i].match(extension_supported[i]);
+        //auto res = extension_requested[i].match(extension_supported[i]);
+        auto res = GenericFeaturesPNextNode::match(extension_requested[i], extension_supported[i]);
         if(!res) return false;
     }
 
@@ -992,7 +996,7 @@ uint32_t get_present_queue_index(VkPhysicalDevice const phys_device,
 
 PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_device_details(
     uint32_t instance_version, VkPhysicalDevice phys_device,
-    std::vector<detail::FeaturesContainer> extension_features_as_template) const {
+    std::vector<detail::GenericFeaturesPNextNode> const& src_extended_features_chain) const {
 	PhysicalDeviceSelector::PhysicalDeviceDesc desc{};
 	desc.phys_device = phys_device;
 	auto queue_families = detail::get_vector_noerror<VkQueueFamilyProperties>(
@@ -1004,23 +1008,31 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 	detail::vulkan_functions().fp_vkGetPhysicalDeviceMemoryProperties(phys_device, &desc.mem_properties);
 
 #if defined(VK_API_VERSION_1_1)
-	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    desc.extension_features = extension_features_as_template;
-    if (instance_version >= VK_API_VERSION_1_1) {
-		detail::FeaturesContainer* prev = nullptr;
-        for(auto& extension : desc.extension_features) {
-            if(prev != nullptr) {
-                prev->header->pNext = extension.header;
+    desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+
+    auto fill_chain = src_extended_features_chain;
+
+    if(!fill_chain.empty() && instance_version >= VK_API_VERSION_1_1) {
+
+        detail::GenericFeaturesPNextNode* prev = nullptr;
+        for (auto& extension : fill_chain) {
+            if (prev != nullptr) {
+                prev->pNext = &extension;
             }
             prev = &extension;
         }
-        if(desc.extension_features.size() > 0) {
-            desc.device_features2.pNext = desc.extension_features.front().header;
-        }
-        detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &desc.device_features2);
+
+        VkPhysicalDeviceFeatures2 local_features{};
+        local_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        local_features.pNext = &fill_chain.front();
+
+        detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2(phys_device, &local_features);
+
     }
+
+    desc.extended_features_chain = fill_chain;
 #endif
-	return desc;
+    return desc;
 }
 
 PhysicalDeviceSelector::Suitable PhysicalDeviceSelector::is_device_suitable(PhysicalDeviceDesc pd) const {
@@ -1089,7 +1101,7 @@ PhysicalDeviceSelector::Suitable PhysicalDeviceSelector::is_device_suitable(Phys
 	}
 
     bool required_features_supported = detail::supports_features(pd.device_features, criteria.required_features,
-                                                                 pd.extension_features, criteria.extension_features);
+                                                                 pd.extended_features_chain, criteria.extended_features_chain);
 	if (!required_features_supported) return Suitable::no;
 
 	bool has_required_memory = false;
@@ -1142,7 +1154,7 @@ detail::Result<PhysicalDevice> PhysicalDeviceSelector::select() const {
 	for (auto& phys_device : physical_devices) {
         phys_device_descriptions.push_back(populate_device_details(instance_info.version,
                                                                    phys_device,
-                                                                   criteria.extension_features));
+                                                                   criteria.extended_features_chain));
 	}
 
 	PhysicalDeviceDesc selected_device{};
@@ -1168,7 +1180,7 @@ detail::Result<PhysicalDevice> PhysicalDeviceSelector::select() const {
 	out_device.physical_device = selected_device.phys_device;
 	out_device.surface = instance_info.surface;
 	out_device.features = criteria.required_features;
-    out_device.extension_features = criteria.extension_features;
+    out_device.extended_features_chain = criteria.extended_features_chain;
 	out_device.properties = selected_device.device_properties;
 	out_device.memory_properties = selected_device.mem_properties;
 	out_device.queue_families = selected_device.queue_families;
@@ -1399,25 +1411,18 @@ detail::Result<Device> DeviceBuilder::build() const {
 		extensions.push_back({ VK_KHR_SWAPCHAIN_EXTENSION_NAME });
 
     bool has_phys_dev_features_2 = false;
+	std::vector<VkBaseOutStructure*> final_pnext_chain;
 
 #if defined(VK_API_VERSION_1_1)
-	// Setup the pNexts of all the extension features
-	std::vector<detail::FeaturesContainer> match = physical_device.extension_features;
     VkPhysicalDeviceFeatures2 local_features2{};
-    if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0) &&
-		match.size() > 0) {
-		detail::FeaturesContainer* prev = nullptr;
-        for(auto& extension : match) {
-            if(prev != nullptr) {
-                prev->header->pNext = extension.header;
-            }
-            prev = &extension;
-        }
-        local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-        local_features2.features = physical_device.features;
-        local_features2.pNext = match.front().header;
+    local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	auto physical_device_extension_features_copy = physical_device.extended_features_chain;
+    if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0)) {
         has_phys_dev_features_2 = true;
-    }
+		for(auto& features_node : physical_device_extension_features_copy) {
+			final_pnext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&features_node));
+		}
+	}
 #endif
 
 	VkDeviceCreateInfo device_create_info = {};
@@ -1428,15 +1433,23 @@ detail::Result<Device> DeviceBuilder::build() const {
 	device_create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	device_create_info.ppEnabledExtensionNames = extensions.data();
 
-	detail::setup_pNext_chain(device_create_info, info.pNext_chain);
+	for(auto& pnext : info.pNext_chain) {
+        final_pnext_chain.push_back(pnext);
+	}
+
+	detail::setup_pNext_chain(device_create_info, final_pnext_chain);
+	for(auto& node : final_pnext_chain) {
+		assert(node->sType != VK_STRUCTURE_TYPE_APPLICATION_INFO);
+	}
 
 #if defined(VK_API_VERSION_1_1)
 	// VUID-VkDeviceCreateInfo-pNext-00373 - don't add pEnabledFeatures if the phys_dev_features_2 is present
     if (has_phys_dev_features_2) {
         device_create_info.pNext = &local_features2;
-		if(info.pNext_chain.size() > 0) {
-			match.back().header->pNext = info.pNext_chain.front();
+		if(!final_pnext_chain.empty()) {
+            local_features2.pNext = final_pnext_chain.front();
 		}
+        device_create_info.pEnabledFeatures = nullptr;
     } else {
 		device_create_info.pEnabledFeatures = &physical_device.features;
 	}
@@ -1678,6 +1691,9 @@ detail::Result<Swapchain> SwapchainBuilder::build() const {
 	VkSwapchainCreateInfoKHR swapchain_create_info = {};
 	swapchain_create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
 	detail::setup_pNext_chain(swapchain_create_info, info.pNext_chain);
+	for(auto& node : info.pNext_chain) {
+        assert(node->sType != VK_STRUCTURE_TYPE_APPLICATION_INFO);
+	}
 	swapchain_create_info.flags = info.create_flags;
 	swapchain_create_info.surface = info.surface;
 	swapchain_create_info.minImageCount = image_count;

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -846,8 +846,8 @@ std::vector<const char*> check_device_extension_support(
 // clang-format off
 bool supports_features(VkPhysicalDeviceFeatures supported,
                        VkPhysicalDeviceFeatures requested,
-                       const std::vector<ExtensionFeatures>& extension_supported,
-                       const std::vector<ExtensionFeatures>& extension_requested) {
+                       std::vector<ExtensionFeatures> const& extension_supported,
+                       std::vector<ExtensionFeatures> const& extension_requested) {
     if (requested.robustBufferAccess && !supported.robustBufferAccess) return false;
     if (requested.fullDrawIndexUint32 && !supported.fullDrawIndexUint32) return false;
     if (requested.imageCubeArray && !supported.imageCubeArray) return false;
@@ -992,7 +992,7 @@ uint32_t get_present_queue_index(VkPhysicalDevice const phys_device,
 
 PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_device_details(
     uint32_t instance_version, VkPhysicalDevice phys_device,
-    std::vector<ExtensionFeatures> extension_features_as_template) const {
+    std::vector<detail::ExtensionFeatures> extension_features_as_template) const {
 	PhysicalDeviceSelector::PhysicalDeviceDesc desc{};
 	desc.phys_device = phys_device;
 	auto queue_families = detail::get_vector_noerror<VkQueueFamilyProperties>(
@@ -1007,7 +1007,7 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     desc.extension_features = extension_features_as_template;
     if (instance_version >= VK_API_VERSION_1_1) {
-        ExtensionFeatures* prev = nullptr;
+		detail::ExtensionFeatures* prev = nullptr;
         for(auto& extension : desc.extension_features) {
             if(prev != nullptr) {
                 prev->structure->pNext = extension.structure;
@@ -1260,12 +1260,12 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t maj
 // Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
     VkPhysicalDeviceVulkan11Features const& features_11) {
-    add_required_features(features_11);
+    add_required_extension_features(features_11);
     return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(
     VkPhysicalDeviceVulkan12Features const& features_12) {
-    add_required_features(features_12);
+	add_required_extension_features(features_12);
     return *this;
 }
 #endif
@@ -1401,21 +1401,24 @@ detail::Result<Device> DeviceBuilder::build() const {
 
     bool has_phys_dev_features_2 = false;
 
-// Setup the pNexts of all the extension features
 #if defined(VK_API_VERSION_1_1)
+	// Setup the pNexts of all the extension features
+	std::vector<detail::ExtensionFeatures> match = physical_device.extension_features;
     VkPhysicalDeviceFeatures2 local_features2{};
+	VkBaseOutStructure* tail = nullptr;
     if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0) &&
-        physical_device.extension_features.size() > 0) {
-        ExtensionFeatures* prev = nullptr;
-        for(auto& extension : physical_device.extension_features) {
+		match.size() > 0) {
+		detail::ExtensionFeatures* prev = nullptr;
+        for(auto& extension : match) {
             if(prev != nullptr) {
                 prev->structure->pNext = extension.structure;
             }
             prev = &extension;
+			tail = prev->structure;
         }
         local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         local_features2.features = physical_device.features;
-        local_features2.pNext = physical_device.extension_features[0].structure;
+        local_features2.pNext = match.front().structure;
         has_phys_dev_features_2 = true;
     }
 #endif
@@ -1427,19 +1430,31 @@ detail::Result<Device> DeviceBuilder::build() const {
 	device_create_info.pQueueCreateInfos = queueCreateInfos.data();
 	device_create_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	device_create_info.ppEnabledExtensionNames = extensions.data();
+
+	detail::setup_pNext_chain(device_create_info, info.pNext_chain);
+
+#if defined(VK_API_VERSION_1_1)
 	// VUID-VkDeviceCreateInfo-pNext-00373 - don't add pEnabledFeatures if the phys_dev_features_2 is present
-    if (!has_phys_dev_features_2) {
-        device_create_info.pEnabledFeatures = &physical_device.features;
-    } else {
+    if (has_phys_dev_features_2) {
         device_create_info.pNext = &local_features2;
-    }
+		if(info.pNext_chain.size() > 0) {
+			match.back().structure->pNext = info.pNext_chain.front();
+		}
+    } else {
+		device_create_info.pEnabledFeatures = &physical_device.features;
+	}
+#else
+	device_create_info.pEnabledFeatures = &physical_device.features;
+#endif
 
 	Device device;
+
 	VkResult res = detail::vulkan_functions().fp_vkCreateDevice(
 	    physical_device.physical_device, &device_create_info, info.allocation_callbacks, &device.device);
 	if (res != VK_SUCCESS) {
 		return { DeviceError::failed_create_device, res };
 	}
+
 	device.physical_device = physical_device;
 	device.surface = physical_device.surface;
 	device.queue_families = physical_device.queue_families;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -459,10 +459,8 @@ class PhysicalDeviceSelector {
         return *this;
     }
 #endif
-    PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features) {
-        criteria.required_features = features;
-        return *this;
-    }
+    // Require a physical device which supports the features in VkPhysicalDeviceFeatures.
+    PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features);
 #if defined(VK_API_VERSION_1_2)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
     // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -549,10 +549,10 @@ class PhysicalDeviceSelector {
 #if defined(VK_API_VERSION_1_2)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
     // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
-    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11);
+    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features features_11);
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
     // Must have vulkan version 1.2
-    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12);
+    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features features_12);
 #endif
 
 	// Used when surface creation happens after physical device selection.

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -538,6 +538,8 @@ class PhysicalDeviceSelector {
 #if defined(VK_API_VERSION_1_1)
     template <typename T>
     PhysicalDeviceSelector& add_required_extension_features(T const& features) {
+		assert(features.sType != 0 &&
+		       "Features struct sType must be filled with the struct's corresponding VkStructureType enum");
         criteria.extension_features.push_back(detail::ExtensionFeatures::make(features));
         return *this;
     }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -115,60 +115,31 @@ template <typename T> class Result {
 	bool m_init;
 };
 
-struct FeaturesContainer {
+struct GenericFeaturesPNextNode {
 
-	FeaturesContainer() = default;
+    GenericFeaturesPNextNode() : sType(static_cast<VkStructureType>(0)),
+                                 pNext(nullptr) {
+        memset(fields, 0, sizeof(fields));
+    }
 
-	FeaturesContainer(FeaturesContainer const& other) { copy(other); }
+    VkStructureType sType = static_cast<VkStructureType>(0);
+    void* pNext = nullptr;
+    VkBool32 fields[256];
 
-	FeaturesContainer(FeaturesContainer&& other) { copy(other); }
+    template <typename T>
+    void set(T const& features) {
+        GenericFeaturesPNextNode node;
+        *reinterpret_cast<T*>(this) = features;
+    }
 
-	FeaturesContainer& operator=(FeaturesContainer const& other) { copy(other); return *this; }
-
-	FeaturesContainer& operator=(FeaturesContainer&& other) { copy(other); return *this; }
-
-	template <typename T>
-	static FeaturesContainer make(T src) {
-		FeaturesContainer extension_features;
-		extension_features.set<T>(src);
-		return extension_features;
-
-	}
-
-	template <typename T>
-	void set(T const& features) {
-		data.resize(sizeof(T));
-		*reinterpret_cast<T*>(data.data()) = features;
-		count = (sizeof(T) - sizeof(VkBaseOutStructure)) / sizeof(VkBool32);
-		header = reinterpret_cast<VkBaseOutStructure*>(data.data());
-		fields = reinterpret_cast<VkBool32*>(data.data() + sizeof(VkBaseOutStructure));
-	}
-
-	bool match(FeaturesContainer const& other) const {
-		if(!header || !other.header || header->sType != other.header->sType) { return false; }
-		for(auto i = 0; i < count; ++i) {
-			if(fields[i] == VK_TRUE && other.fields[i] == VK_FALSE) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	VkBaseOutStructure* header = nullptr;
-private:
-
-	// Just to avoid having it copied in 4 places
-	void copy(FeaturesContainer const& other) {
-		data = other.data;
-		count = other.count;
-		header = reinterpret_cast<VkBaseOutStructure*>(data.data());
-		fields = reinterpret_cast<VkBool32*>(data.data() + sizeof(VkBaseOutStructure));
-	}
-
-	std::vector<char> data;
-	VkBool32* fields = nullptr;
-	void* extend = nullptr; // Future proofing
-	int count = 0;
+    static bool match(GenericFeaturesPNextNode const& requested, GenericFeaturesPNextNode const& supported) {
+        assert(requested.sType == supported.sType &&
+               "Non-matching sTypes in features nodes!");
+        for (uint32_t i = 0; i < (sizeof(fields) / sizeof(VkBool32)); i++) {
+            if (requested.fields[i] && !supported.fields[i]) return false;
+        }
+        return true;
+    }
 
 };
 
@@ -412,7 +383,7 @@ struct PhysicalDevice {
 	uint32_t instance_version = VK_MAKE_VERSION(1, 0, 0);
 	std::vector<const char*> extensions_to_enable;
 	std::vector<VkQueueFamilyProperties> queue_families;
-    std::vector<detail::FeaturesContainer> extension_features;
+    std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 	bool defer_surface_initialization = false;
 	friend class PhysicalDeviceSelector;
 	friend class DeviceBuilder;
@@ -479,7 +450,9 @@ class PhysicalDeviceSelector {
     PhysicalDeviceSelector& add_required_extension_features(T const& features) {
 		assert(features.sType != 0 &&
 		       "Features struct sType must be filled with the struct's corresponding VkStructureType enum");
-        criteria.extension_features.push_back(detail::FeaturesContainer::make(features));
+		detail::GenericFeaturesPNextNode node;
+		node.set(features);
+        criteria.extended_features_chain.push_back(node);
         return *this;
     }
 #endif
@@ -521,7 +494,7 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceMemoryProperties mem_properties{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 device_features2{};
-        std::vector<detail::FeaturesContainer> extension_features;
+        std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 #endif
 	};
 
@@ -530,7 +503,7 @@ class PhysicalDeviceSelector {
 
     PhysicalDeviceDesc populate_device_details(uint32_t instance_version,
                                                VkPhysicalDevice phys_device,
-                                               std::vector<detail::FeaturesContainer> extension_features_as_template) const;
+                                               std::vector<detail::GenericFeaturesPNextNode> const& src_extended_features_chain) const;
 
 	struct SelectionCriteria {
 		PreferredDeviceType preferred_type = PreferredDeviceType::discrete;
@@ -552,7 +525,7 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceFeatures required_features{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 required_features2{};
-        std::vector<detail::FeaturesContainer> extension_features;
+        std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 #endif
 		bool defer_surface_initialization = false;
 		bool use_first_gpu_unconditionally = false;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -117,38 +117,73 @@ template <typename T> class Result {
 
 struct ExtensionFeatures {
 
-    using DeleteProc = void(*)(ExtensionFeatures&);
-    using UpdateProc = void(*)(ExtensionFeatures&);
-    using CopyProc = void(*)(const ExtensionFeatures&, ExtensionFeatures&);
+	struct StructureContainer {
+
+		struct Header {
+			VkStructureType sType;
+			void* pNext;
+		};
+
+		StructureContainer() = default;
+
+		StructureContainer (StructureContainer const& other) { copy(other); }
+
+		StructureContainer (StructureContainer&& other) { copy(other); }
+
+		StructureContainer& operator=(StructureContainer const& other) { copy(other); return *this; }
+
+		StructureContainer& operator=(StructureContainer&& other) { copy(other); return *this; }
+
+		template <typename T>
+		void set(T const& features) {
+			data.resize(sizeof(T));
+			*reinterpret_cast<T*>(data.data()) = features;
+			count = (sizeof(T) - sizeof(Header)) / sizeof(VkBool32);
+			header = reinterpret_cast<Header*>(data.data());
+			fields = reinterpret_cast<VkBool32*>(data.data() + sizeof(Header));
+		}
+
+		bool match(StructureContainer const& other) const {
+			if(!header || !other.header || header->sType != other.header->sType) { return false; }
+			for(auto i = 0; i < count; ++i) {
+				if(fields[i] == VK_TRUE && other.fields[i] == VK_FALSE) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		Header* header = nullptr;
+	private:
+
+		// Just to avoid having it copied in 4 places
+		void copy(StructureContainer const& other) {
+			data = other.data;
+			count = other.count;
+			header = reinterpret_cast<Header*>(data.data());
+			fields = reinterpret_cast<VkBool32*>(data.data() + sizeof(Header));
+		}
+
+		std::vector<char> data;
+		VkBool32* fields = nullptr;
+		void* extend = nullptr; // Future proofing
+		int count = 0;
+
+	};
 
     ExtensionFeatures() = default;
 
-    ExtensionFeatures (const ExtensionFeatures& other) : delete_proc(other.delete_proc),
-                                                         update_proc(other.update_proc),
-                                                         copy_proc(other.copy_proc) {
-        if(copy_proc) { copy_proc(other, *this); }
-    }
+    ExtensionFeatures (ExtensionFeatures const& other) : structure(other.structure) {}
 
-    ExtensionFeatures (ExtensionFeatures&& other) : delete_proc(std::exchange(other.delete_proc, nullptr)),
-                                                    update_proc(std::exchange(other.update_proc, nullptr)),
-                                                    copy_proc(std::exchange(other.copy_proc, nullptr)),
-                                                    structure(std::exchange(other.structure, nullptr)),
-                                                    fields(std::exchange(other.fields, {})) {}
+    ExtensionFeatures (ExtensionFeatures&& other) : structure(std::exchange(other.structure, {})) {}
 
-    ExtensionFeatures& operator=(const ExtensionFeatures& other) {
-        delete_proc = other.delete_proc;
-        update_proc = other.update_proc;
-        copy_proc = other.copy_proc;
-        if(copy_proc) { copy_proc(other, *this); }
+    ExtensionFeatures& operator=(ExtensionFeatures const& other) {
+        structure = other.structure;
         return *this;
     }
 
     ExtensionFeatures& operator=(ExtensionFeatures&& other) {
-        delete_proc = std::exchange(other.delete_proc, nullptr);
-        update_proc = std::exchange(other.update_proc, nullptr);
-        copy_proc = std::exchange(other.copy_proc, nullptr);
-        structure = std::exchange(other.structure, nullptr);
-        fields = std::exchange(other.fields, {});
+		structure = std::exchange(other.structure, {});
         return *this;
     }
 
@@ -156,81 +191,15 @@ struct ExtensionFeatures {
     static ExtensionFeatures make(T src) {
 
         ExtensionFeatures extension_features;
-        T* new_features_structure = new T;
-        *new_features_structure = src;
-        extension_features.structure = reinterpret_cast<VkBaseOutStructure*>(new_features_structure);
-
-        extension_features.delete_proc = [](ExtensionFeatures& features) {
-
-          features.fields = {};
-          if(features.structure) {
-              auto casted = reinterpret_cast<T *>(features.structure);
-              delete casted;
-          }
-
-        };
-
-        extension_features.update_proc = [](ExtensionFeatures& features) {
-
-            auto structure_field_count = (sizeof(T) - (sizeof(void*) * 2)) / sizeof(VkBool32);
-            features.fields.resize(structure_field_count);
-            memcpy(features.fields.data(),
-                   reinterpret_cast<unsigned char*>(features.structure) + (sizeof(void*) * 2),
-                   sizeof(VkBool32) * features.fields.size());
-
-        };
-
-        extension_features.copy_proc = [](const ExtensionFeatures& src, ExtensionFeatures& dst) {
-
-          if(dst.structure) {
-              auto casted = reinterpret_cast<T*>(dst.structure);
-              delete casted;
-          }
-          T* new_features_structure = new T;
-          *new_features_structure = *reinterpret_cast<T*>(src.structure);
-          dst.structure = reinterpret_cast<VkBaseOutStructure*>(new_features_structure);
-          dst.fields = src.fields;
-
-        };
-
-		extension_features.update();
-
+        extension_features.structure.set<T>(src);
         return extension_features;
-    }
-
-	void update() {
-
-		if(update_proc) {
-			update_proc(*this);
-		}
-
-	}
-
-    bool match(const ExtensionFeatures& other) const {
-
-        if(!structure || !other.structure || structure->sType != other.structure->sType) { return false; }
-
-        for(auto i = 0; i < fields.size(); ++i) {
-            if(fields[i] == VK_TRUE && other.fields[i] == VK_FALSE) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    ~ExtensionFeatures() {
-
-        if(delete_proc) { delete_proc(*this); }
 
     }
 
-    VkBaseOutStructure* structure = nullptr;
-    std::vector<VkBool32> fields;
-    private:
-    DeleteProc delete_proc = nullptr;
-    UpdateProc update_proc = nullptr;
-    CopyProc copy_proc = nullptr;
+    bool match(const ExtensionFeatures& other) const { return structure.match(other.structure); }
+
+	StructureContainer structure;
+
 };
 
 } // namespace detail

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -115,86 +115,6 @@ template <typename T> class Result {
 	bool m_init;
 };
 
-} // namespace detail
-
-enum class InstanceError {
-	vulkan_unavailable,
-	vulkan_version_unavailable,
-	vulkan_version_1_1_unavailable,
-	vulkan_version_1_2_unavailable,
-	failed_create_instance,
-	failed_create_debug_messenger,
-	requested_layers_not_present,
-	requested_extensions_not_present,
-	windowing_extensions_not_present,
-};
-enum class PhysicalDeviceError {
-	no_surface_provided,
-	failed_enumerate_physical_devices,
-	no_physical_devices_found,
-	no_suitable_device,
-};
-enum class QueueError {
-	present_unavailable,
-	graphics_unavailable,
-	compute_unavailable,
-	transfer_unavailable,
-	queue_index_out_of_range,
-	invalid_queue_family_index
-};
-enum class DeviceError {
-	failed_create_device,
-};
-enum class SwapchainError {
-	surface_handle_not_provided,
-	failed_query_surface_support_details,
-	failed_create_swapchain,
-	failed_get_swapchain_images,
-	failed_create_swapchain_image_views,
-};
-
-std::error_code make_error_code(InstanceError instance_error);
-std::error_code make_error_code(PhysicalDeviceError physical_device_error);
-std::error_code make_error_code(QueueError queue_error);
-std::error_code make_error_code(DeviceError device_error);
-std::error_code make_error_code(SwapchainError swapchain_error);
-
-const char* to_string_message_severity(VkDebugUtilsMessageSeverityFlagBitsEXT s);
-const char* to_string_message_type(VkDebugUtilsMessageTypeFlagsEXT s);
-
-const char* to_string(InstanceError err);
-const char* to_string(PhysicalDeviceError err);
-const char* to_string(QueueError err);
-const char* to_string(DeviceError err);
-const char* to_string(SwapchainError err);
-
-// Gathers useful information about the available vulkan capabilities, like layers and instance
-// extensions. Use this for enabling features conditionally, ie if you would like an extension but
-// can use a fallback if it isn't supported but need to know if support is available first.
-struct SystemInfo {
-	private:
-	SystemInfo();
-
-	public:
-	// Use get_system_info to create a SystemInfo struct. This is because loading vulkan could fail.
-	static detail::Result<SystemInfo> get_system_info();
-	static detail::Result<SystemInfo> get_system_info(PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr);
-
-	// Returns true if a layer is available
-	bool is_layer_available(const char* layer_name) const;
-	// Returns true if an extension is available
-	bool is_extension_available(const char* extension_name) const;
-
-	std::vector<VkLayerProperties> available_layers;
-	std::vector<VkExtensionProperties> available_extensions;
-	bool validation_layers_available = false;
-	bool debug_utils_available = false;
-};
-
-
-class InstanceBuilder;
-class PhysicalDeviceSelector;
-
 struct ExtensionFeatures {
 
     using DeleteProc = void(*)(ExtensionFeatures&);
@@ -312,6 +232,86 @@ struct ExtensionFeatures {
     UpdateProc update_proc = nullptr;
     CopyProc copy_proc = nullptr;
 };
+
+} // namespace detail
+
+enum class InstanceError {
+	vulkan_unavailable,
+	vulkan_version_unavailable,
+	vulkan_version_1_1_unavailable,
+	vulkan_version_1_2_unavailable,
+	failed_create_instance,
+	failed_create_debug_messenger,
+	requested_layers_not_present,
+	requested_extensions_not_present,
+	windowing_extensions_not_present,
+};
+enum class PhysicalDeviceError {
+	no_surface_provided,
+	failed_enumerate_physical_devices,
+	no_physical_devices_found,
+	no_suitable_device,
+};
+enum class QueueError {
+	present_unavailable,
+	graphics_unavailable,
+	compute_unavailable,
+	transfer_unavailable,
+	queue_index_out_of_range,
+	invalid_queue_family_index
+};
+enum class DeviceError {
+	failed_create_device,
+};
+enum class SwapchainError {
+	surface_handle_not_provided,
+	failed_query_surface_support_details,
+	failed_create_swapchain,
+	failed_get_swapchain_images,
+	failed_create_swapchain_image_views,
+};
+
+std::error_code make_error_code(InstanceError instance_error);
+std::error_code make_error_code(PhysicalDeviceError physical_device_error);
+std::error_code make_error_code(QueueError queue_error);
+std::error_code make_error_code(DeviceError device_error);
+std::error_code make_error_code(SwapchainError swapchain_error);
+
+const char* to_string_message_severity(VkDebugUtilsMessageSeverityFlagBitsEXT s);
+const char* to_string_message_type(VkDebugUtilsMessageTypeFlagsEXT s);
+
+const char* to_string(InstanceError err);
+const char* to_string(PhysicalDeviceError err);
+const char* to_string(QueueError err);
+const char* to_string(DeviceError err);
+const char* to_string(SwapchainError err);
+
+// Gathers useful information about the available vulkan capabilities, like layers and instance
+// extensions. Use this for enabling features conditionally, ie if you would like an extension but
+// can use a fallback if it isn't supported but need to know if support is available first.
+struct SystemInfo {
+	private:
+	SystemInfo();
+
+	public:
+	// Use get_system_info to create a SystemInfo struct. This is because loading vulkan could fail.
+	static detail::Result<SystemInfo> get_system_info();
+	static detail::Result<SystemInfo> get_system_info(PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr);
+
+	// Returns true if a layer is available
+	bool is_layer_available(const char* layer_name) const;
+	// Returns true if an extension is available
+	bool is_extension_available(const char* extension_name) const;
+
+	std::vector<VkLayerProperties> available_layers;
+	std::vector<VkExtensionProperties> available_extensions;
+	bool validation_layers_available = false;
+	bool debug_utils_available = false;
+};
+
+
+class InstanceBuilder;
+class PhysicalDeviceSelector;
 
 struct Instance {
 	VkInstance instance = VK_NULL_HANDLE;
@@ -473,7 +473,7 @@ struct PhysicalDevice {
 	uint32_t instance_version = VK_MAKE_VERSION(1, 0, 0);
 	std::vector<const char*> extensions_to_enable;
 	std::vector<VkQueueFamilyProperties> queue_families;
-    mutable std::vector<ExtensionFeatures> extension_features;
+    std::vector<detail::ExtensionFeatures> extension_features;
 	bool defer_surface_initialization = false;
 	friend class PhysicalDeviceSelector;
 	friend class DeviceBuilder;
@@ -534,16 +534,15 @@ class PhysicalDeviceSelector {
 	// Require a physical device that supports a (major, minor) version of vulkan.
 	PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);
 
-// Require a physical device which supports a specific set of general/extension features.
-    template <typename T>
-    PhysicalDeviceSelector& add_required_features(T const& features) {
+	// Require a physical device which supports a specific set of general/extension features.
 #if defined(VK_API_VERSION_1_1)
-        criteria.extension_features.push_back(ExtensionFeatures::make(features));
-#endif
+    template <typename T>
+    PhysicalDeviceSelector& add_required_extension_features(T const& features) {
+        criteria.extension_features.push_back(detail::ExtensionFeatures::make(features));
         return *this;
     }
-    template<>
-    PhysicalDeviceSelector& add_required_features<VkPhysicalDeviceFeatures>(VkPhysicalDeviceFeatures const& features) {
+#endif
+    PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features) {
         criteria.required_features = features;
         return *this;
     }
@@ -581,7 +580,7 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceMemoryProperties mem_properties{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 device_features2{};
-        std::vector<ExtensionFeatures> extension_features;
+        std::vector<detail::ExtensionFeatures> extension_features;
 #endif
 	};
 
@@ -590,7 +589,7 @@ class PhysicalDeviceSelector {
 
     PhysicalDeviceDesc populate_device_details(uint32_t instance_version,
                                                VkPhysicalDevice phys_device,
-                                               std::vector<ExtensionFeatures> extension_features_as_template) const;
+                                               std::vector<detail::ExtensionFeatures> extension_features_as_template) const;
 
 	struct SelectionCriteria {
 		PreferredDeviceType preferred_type = PreferredDeviceType::discrete;
@@ -612,7 +611,7 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceFeatures required_features{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 required_features2{};
-        std::vector<ExtensionFeatures> extension_features;
+        std::vector<detail::ExtensionFeatures> extension_features;
 #endif
 		bool defer_surface_initialization = false;
 		bool use_first_gpu_unconditionally = false;
@@ -670,6 +669,13 @@ class DeviceBuilder {
 	// If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
 	DeviceBuilder& custom_queue_setup(std::vector<CustomQueueDescription> queue_descriptions);
 
+	// Add a structure to the pNext chain of VkDeviceCreateInfo.
+	// The structure must be valid when DeviceBuilder::build() is called.
+	template <typename T> DeviceBuilder& add_pNext(T* structure) {
+		info.pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(structure));
+		return *this;
+	}
+
 	// Provide custom allocation callbacks.
 	DeviceBuilder& set_allocation_callbacks(VkAllocationCallbacks* callbacks);
 
@@ -677,6 +683,7 @@ class DeviceBuilder {
 	PhysicalDevice physical_device;
 	struct DeviceInfo {
 		VkDeviceCreateFlags flags = 0;
+		std::vector<VkBaseOutStructure*> pNext_chain;
 		std::vector<CustomQueueDescription> queue_descriptions;
 		VkAllocationCallbacks* allocation_callbacks = VK_NULL_HANDLE;
 	} info;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -195,6 +195,105 @@ struct SystemInfo {
 class InstanceBuilder;
 class PhysicalDeviceSelector;
 
+struct ExtensionFeatures {
+
+    using DeleteProc = void(*)(ExtensionFeatures&);
+    using CopyProc = void(*)(const ExtensionFeatures&, ExtensionFeatures&);
+
+    ExtensionFeatures() = default;
+
+    ExtensionFeatures (const ExtensionFeatures& other) : delete_proc(other.delete_proc), copy_proc(other.copy_proc) {
+        if(copy_proc) { copy_proc(other, *this); }
+    }
+
+    ExtensionFeatures (ExtensionFeatures&& other) : delete_proc(std::exchange(other.delete_proc, nullptr)),
+                                                    copy_proc(std::exchange(other.copy_proc, nullptr)),
+                                                    structure(std::exchange(other.structure, nullptr)),
+                                                    fields(std::exchange(other.fields, {})) {}
+
+    ExtensionFeatures& operator=(const ExtensionFeatures& other) {
+        delete_proc = other.delete_proc;
+        copy_proc = other.copy_proc;
+        if(copy_proc) { copy_proc(other, *this); }
+        return *this;
+    }
+
+    ExtensionFeatures& operator=(ExtensionFeatures&& other) {
+        delete_proc = std::exchange(other.delete_proc, nullptr);
+        copy_proc = std::exchange(other.copy_proc, nullptr);
+        structure = std::exchange(other.structure, nullptr);
+        fields = std::exchange(other.fields, {});
+        return *this;
+    }
+
+    template <typename T>
+    static ExtensionFeatures make(T src) {
+
+        ExtensionFeatures extension_features;
+        T* new_features_structure = new T;
+        *new_features_structure = src;
+        extension_features.structure = reinterpret_cast<VkBaseOutStructure*>(new_features_structure);
+
+        auto structure_field_count =
+            (sizeof(T) - (sizeof(VkStructureType) + sizeof(void*))) / sizeof(VkBool32);
+        extension_features.fields.resize(structure_field_count);
+        memcpy(extension_features.fields.data(),
+               reinterpret_cast<unsigned char*>(extension_features.structure) +
+               (sizeof(VkStructureType) + sizeof(void*)),
+               sizeof(VkBool32) * extension_features.fields.size());
+
+        extension_features.delete_proc = [](ExtensionFeatures& features) {
+
+          features.fields = {};
+          if(features.structure) {
+              auto casted = reinterpret_cast<T *>(features.structure);
+              delete casted;
+          }
+
+        };
+
+        extension_features.copy_proc = [](const ExtensionFeatures& src, ExtensionFeatures& dst) {
+
+          if(dst.structure) {
+              auto casted = reinterpret_cast<T*>(dst.structure);
+              delete casted;
+          }
+          T* new_features_structure = new T;
+          *new_features_structure = *reinterpret_cast<T*>(src.structure);
+          dst.structure = reinterpret_cast<VkBaseOutStructure*>(new_features_structure);
+          dst.fields = src.fields;
+
+        };
+
+        return extension_features;
+    }
+
+    bool match(const ExtensionFeatures& other) const {
+
+        if(!structure || !other.structure || structure->sType != other.structure->sType) { return false; }
+
+        for(auto i = 0; i < fields.size(); ++i) {
+            if(fields[i] == VK_TRUE && other.fields[i] == VK_FALSE) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    ~ExtensionFeatures() {
+
+        if(delete_proc) { delete_proc(*this); }
+
+    }
+
+    VkBaseOutStructure* structure = nullptr;
+    std::vector<VkBool32> fields;
+    private:
+    DeleteProc delete_proc = {};
+    CopyProc copy_proc = {};
+};
+
 struct Instance {
 	VkInstance instance = VK_NULL_HANDLE;
 	VkDebugUtilsMessengerEXT debug_messenger = VK_NULL_HANDLE;
@@ -335,10 +434,6 @@ struct PhysicalDevice {
 	VkSurfaceKHR surface = VK_NULL_HANDLE;
 
 	VkPhysicalDeviceFeatures features{};
-#if defined(VK_API_VERSION_1_2)
-	VkPhysicalDeviceVulkan11Features features_11{};
-	VkPhysicalDeviceVulkan12Features features_12{};
-#endif
 	VkPhysicalDeviceProperties properties{};
 	VkPhysicalDeviceMemoryProperties memory_properties{};
 
@@ -359,6 +454,7 @@ struct PhysicalDevice {
 	uint32_t instance_version = VK_MAKE_VERSION(1, 0, 0);
 	std::vector<const char*> extensions_to_enable;
 	std::vector<VkQueueFamilyProperties> queue_families;
+    mutable std::vector<ExtensionFeatures> extension_features;
 	bool defer_surface_initialization = false;
 	friend class PhysicalDeviceSelector;
 	friend class DeviceBuilder;
@@ -419,16 +515,26 @@ class PhysicalDeviceSelector {
 	// Require a physical device that supports a (major, minor) version of vulkan.
 	PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);
 
-	// Require a physical device which supports the features in VkPhysicalDeviceFeatures.
-	PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features);
-
+// Require a physical device which supports a specific set of general/extension features.
+    template <typename T>
+    PhysicalDeviceSelector& add_required_features(T const& features) {
+#if defined(VK_API_VERSION_1_1)
+        criteria.extension_features.push_back(ExtensionFeatures::make(features));
+#endif
+        return *this;
+    }
+    template<>
+    PhysicalDeviceSelector& add_required_features<VkPhysicalDeviceFeatures>(VkPhysicalDeviceFeatures const& features) {
+        criteria.required_features = features;
+        return *this;
+    }
 #if defined(VK_API_VERSION_1_2)
-	// Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
-	// Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
-	PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11);
-	// Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
-	// Must have vulkan version 1.2
-	PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12);
+    // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
+    // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
+    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11);
+    // Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
+    // Must have vulkan version 1.2
+    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12);
 #endif
 
 	// Used when surface creation happens after physical device selection.
@@ -456,13 +562,16 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceMemoryProperties mem_properties{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 device_features2{};
-#endif
-#if defined(VK_API_VERSION_1_2)
-		VkPhysicalDeviceVulkan11Features device_features_11{};
-		VkPhysicalDeviceVulkan12Features device_features_12{};
+        std::vector<ExtensionFeatures> extension_features;
 #endif
 	};
-	PhysicalDeviceDesc populate_device_details(uint32_t instance_version, VkPhysicalDevice phys_device) const;
+
+    // We copy the extension features stored in the selector criteria under the prose of a "template" to
+    // ensure that after fetching everything is compared 1:1 during a match.
+
+    PhysicalDeviceDesc populate_device_details(uint32_t instance_version,
+                                               VkPhysicalDevice phys_device,
+                                               std::vector<ExtensionFeatures> extension_features_as_template) const;
 
 	struct SelectionCriteria {
 		PreferredDeviceType preferred_type = PreferredDeviceType::discrete;
@@ -484,13 +593,8 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceFeatures required_features{};
 #if defined(VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 required_features2{};
+        std::vector<ExtensionFeatures> extension_features;
 #endif
-
-#if defined(VK_API_VERSION_1_2)
-		VkPhysicalDeviceVulkan11Features required_features_11{};
-		VkPhysicalDeviceVulkan12Features required_features_12{};
-#endif
-
 		bool defer_surface_initialization = false;
 		bool use_first_gpu_unconditionally = false;
 	} criteria;
@@ -547,13 +651,6 @@ class DeviceBuilder {
 	// If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
 	DeviceBuilder& custom_queue_setup(std::vector<CustomQueueDescription> queue_descriptions);
 
-	// Add a structure to the pNext chain of VkDeviceCreateInfo.
-	// The structure must be valid when DeviceBuilder::build() is called.
-	template <typename T> DeviceBuilder& add_pNext(T* structure) {
-		info.pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(structure));
-		return *this;
-	}
-
 	// Provide custom allocation callbacks.
 	DeviceBuilder& set_allocation_callbacks(VkAllocationCallbacks* callbacks);
 
@@ -561,8 +658,6 @@ class DeviceBuilder {
 	PhysicalDevice physical_device;
 	struct DeviceInfo {
 		VkDeviceCreateFlags flags = 0;
-		std::vector<VkBaseOutStructure*> pNext_chain;
-
 		std::vector<CustomQueueDescription> queue_descriptions;
 		VkAllocationCallbacks* allocation_callbacks = VK_NULL_HANDLE;
 	} info;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -549,10 +549,10 @@ class PhysicalDeviceSelector {
 #if defined(VK_API_VERSION_1_2)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
     // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
-    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11);
+    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11);
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
     // Must have vulkan version 1.2
-    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12);
+    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12);
 #endif
 
 	// Used when surface creation happens after physical device selection.

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -454,8 +454,10 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 		// Requires a device that supports multiview and bufferDeviceAddress
 		{
 			VkPhysicalDeviceVulkan11Features features_11{};
+			features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 			features_11.multiview = true;
 			VkPhysicalDeviceVulkan12Features features_12{};
+			features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
 			features_12.bufferDeviceAddress = true;
 
 			vkb::PhysicalDeviceSelector selector(instance_ret.value());
@@ -472,6 +474,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 		// protectedMemory should NOT be supported
 		{
 			VkPhysicalDeviceVulkan11Features features_11{};
+			features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 			features_11.protectedMemory = true;
 
 			vkb::PhysicalDeviceSelector selector(instance_ret.value());

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -106,7 +106,7 @@ TEST_CASE("instance configuration", "[VkBootstrap.bootstrap]") {
 TEST_CASE("Headless Vulkan", "[VkBootstrap.bootstrap]") {
 	vkb::InstanceBuilder builder;
 
-	auto instance_ret = builder.request_validation_layers().set_headless().build();
+	auto instance_ret = builder.request_validation_layers().set_headless().use_default_debug_messenger().build();
 	REQUIRE(instance_ret.has_value());
 
 	vkb::PhysicalDeviceSelector phys_device_selector(instance_ret.value());
@@ -127,7 +127,7 @@ TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
 	auto window = create_window_glfw("Device Configuration");
 	vkb::InstanceBuilder builder;
 
-	auto instance_ret = builder.request_validation_layers().require_api_version(1, 1).build();
+	auto instance_ret = builder.request_validation_layers().require_api_version(1, 1).use_default_debug_messenger().build();
 	REQUIRE(instance_ret.has_value());
 	auto surface = create_surface_glfw(instance_ret.value().instance, window);
 
@@ -192,7 +192,7 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 		auto window = create_window_glfw("Swapchain");
 		vkb::InstanceBuilder builder;
 
-		auto instance_ret = builder.request_validation_layers().build();
+		auto instance_ret = builder.request_validation_layers().use_default_debug_messenger().build();
 		REQUIRE(instance_ret.has_value());
 		auto surface = create_surface_glfw(instance_ret.value().instance, window);
 
@@ -320,7 +320,7 @@ TEST_CASE("Allocation Callbacks", "[VkBootstrap.bootstrap]") {
 	vkb::InstanceBuilder builder;
 
 	auto instance_ret =
-	    builder.request_validation_layers().set_allocation_callbacks(&allocation_callbacks).build();
+	    builder.request_validation_layers().set_allocation_callbacks(&allocation_callbacks).use_default_debug_messenger().build();
 	REQUIRE(instance_ret.has_value());
 	auto surface = create_surface_glfw(instance_ret.value().instance, window);
 
@@ -417,7 +417,7 @@ TEST_CASE("Querying Required Extension Features", "[VkBootstrap.version]") {
 		vkb::InstanceBuilder builder;
 
 		auto instance_ret =
-			builder.request_validation_layers().require_api_version(1, 2).set_headless().build();
+			builder.request_validation_layers().require_api_version(1, 2).set_headless().use_default_debug_messenger().build();
 		REQUIRE(instance_ret.has_value());
 		// Requires a device that supports runtime descriptor arrays via descriptor indexing extension.
 		{
@@ -449,7 +449,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 		vkb::InstanceBuilder builder;
 
 		auto instance_ret =
-		    builder.request_validation_layers().require_api_version(1, 2).set_headless().build();
+		    builder.request_validation_layers().require_api_version(1, 2).set_headless().use_default_debug_messenger().build();
 		REQUIRE(instance_ret.has_value());
 		// Requires a device that supports multiview and bufferDeviceAddress
 		{


### PR DESCRIPTION
Recreated PR as breaking bug has been remedied.

This PR is a bit of an overhaul of how features are handled internally and mainly affects `DeviceBuilder` and `PhysicalDeviceSelector`.

I added a crude reflection container that handles ownership/matching/destruction of said containers specific features struct instance. Vectors of these containers are used in both device creation and in physical device selection to verify that the specific feature fields requested in the feature structs are properly supported by a device.

Awhile ago I had to hack in some explicit checks for specific descriptor indexing features. I decided to try and make a generic impl that would support all range of feature structures so that we don't have to explicitly create a specific chunk of logic for every possible set of features there is.

Because it is generic, most of the pieces that were explicitly made around `VkPhysicalDeviceVulkan11Features`/`VkPhysicalDeviceVulkan12Features` have been removed. `set_required_features_11` and `set_required_features_12` still exist, but they are now essentially just wrappers around `add_required_features`.