### PR TITLE
Revert "CMake: add an option to enable warnings as errors"

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -54,7 +54,7 @@ jobs:
         sudo apt-get install -y vulkan-headers libvulkan-dev xorg-dev
 
     - name: CMake Configure
-      run: cmake -Bbuild -DVK_BOOTSTRAP_WERROR=ON -DVK_BOOTSTRAP_TEST=ON -DCMAKE_BUILD_TYPE=Debug
+      run: cmake -Bbuild -DVK_BOOTSTRAP_TEST=ON -DCMAKE_BUILD_TYPE=Debug
 
     - name: CMake Build
       run: cmake --build build
@@ -79,7 +79,7 @@ jobs:
         echo "VULKAN_SDK=./Vulkan-Headers" >> $GITHUB_ENV
 
     - name: CMake Configure
-      run: cmake -Bbuild -DVK_BOOTSTRAP_WERROR=ON -DVK_BOOTSTRAP_TEST=ON -DCMAKE_BUILD_TYPE=Debug
+      run: cmake -Bbuild -DVK_BOOTSTRAP_TEST=ON -DCMAKE_BUILD_TYPE=Debug
 
     - name: CMake Build
       run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(VulkanBootstrap)
 
-option(VK_BOOTSTRAP_WERROR "Enable warnings as errors during compilation" OFF)
-
 add_library(vk-boostrap-vulkan-headers INTERFACE)
 
 set(VK_BOOTSTRAP_VULKAN_HEADER_DIR "" CACHE STRING "Specify the location of the Vulkan-Headers include directory.")
@@ -45,21 +43,13 @@ target_compile_options(vk-bootstrap-compiler-warnings
         $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,${VK_BOOTSTRAP_COMPILER_CLANGPP}>:
         -Wall
         -Wextra
+        -pedantic-errors
         -Wconversion
         -Wsign-conversion>
         $<$<CXX_COMPILER_ID:MSVC>:
+        /WX
         /W4>
         )
-
-if(VK_BOOTSTRAP_WERROR)
-  target_compile_options(vk-bootstrap-compiler-warnings
-          INTERFACE
-          $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,${VK_BOOTSTRAP_COMPILER_CLANGPP}>:
-          -pedantic-errors>
-          $<$<CXX_COMPILER_ID:MSVC>:
-          /WX>
-          )
-endif()
 
 target_include_directories(vk-bootstrap PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>

--- a/README.md
+++ b/README.md
@@ -146,6 +146,5 @@ cmake ../path/to/your_project/ -DVK_BOOTSTRAP_TEST=ON
 ### Build Options
 | Name | Type |  Default Value | Description |
 | ---- | --- | ---- | ----- | 
-| `VK_BOOTSTRAP_WERROR` | bool | `OFF` | Enable warnings as errors during compilation. |
 | `VK_BOOTSTRAP_TEST` | bool | `OFF` | Enable building of the tests in this project. Will download GLFW and Catch2 automatically if enabled. |
 | `VK_BOOTSTRAP_VULKAN_HEADER_DIR` | string | `""` | Optional. Specify the directory that contains the Vulkan Headers. Useful if you are downloading the headers manually and don't want vk-bootstrap to download them itself. |


### PR DESCRIPTION
Reverts charles-lunarg/vk-bootstrap#61

Needs to get compilation working under Ubuntu