### PR TITLE
Refactor internal queue selection logic

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1607,7 +1607,7 @@ SwapchainBuilder::SwapchainBuilder(Device const& device) {
 	info.surface = device.surface;
 	auto present = device.get_queue_index(QueueType::present);
 	auto graphics = device.get_queue_index(QueueType::graphics);
-	// TODO: handle error of queue's not available
+	assert(graphics.has_value() && present.has_value() && "Graphics and Present queue indexes must be valid");
 	info.graphics_queue_index = present.value();
 	info.present_queue_index = graphics.value();
 	info.allocation_callbacks = device.allocation_callbacks;
@@ -1620,7 +1620,7 @@ SwapchainBuilder::SwapchainBuilder(Device const& device, VkSurfaceKHR const surf
 	temp_device.surface = surface;
 	auto present = temp_device.get_queue_index(QueueType::present);
 	auto graphics = temp_device.get_queue_index(QueueType::graphics);
-	// TODO: handle error of queue's not available
+	assert(graphics.has_value() && present.has_value() && "Graphics and Present queue indexes must be valid");
 	info.graphics_queue_index = present.value();
 	info.present_queue_index = graphics.value();
 	info.allocation_callbacks = device.allocation_callbacks;

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1030,14 +1030,18 @@ PhysicalDeviceSelector::Suitable PhysicalDeviceSelector::is_device_suitable(Phys
 	if (criteria.required_version > pd.device_properties.apiVersion) return Suitable::no;
 	if (criteria.desired_version > pd.device_properties.apiVersion) suitable = Suitable::partial;
 
-	bool dedicated_compute =
-	    detail::get_dedicated_queue_index(pd.queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
-	bool dedicated_transfer =
-	    detail::get_dedicated_queue_index(pd.queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	bool dedicated_compute = detail::get_dedicated_queue_index(pd.queue_families,
+	                             VK_QUEUE_COMPUTE_BIT,
+	                             VK_QUEUE_TRANSFER_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	bool dedicated_transfer = detail::get_dedicated_queue_index(pd.queue_families,
+	                              VK_QUEUE_TRANSFER_BIT,
+	                              VK_QUEUE_COMPUTE_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
 	bool separate_compute =
-	    detail::get_separate_queue_index(pd.queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	    detail::get_separate_queue_index(pd.queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) !=
+	    detail::QUEUE_INDEX_MAX_VALUE;
 	bool separate_transfer =
-	    detail::get_separate_queue_index(pd.queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	    detail::get_separate_queue_index(pd.queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) !=
+	    detail::QUEUE_INDEX_MAX_VALUE;
 
 	bool present_queue =
 	    detail::get_present_queue_index(pd.phys_device, instance_info.surface, pd.queue_families) !=
@@ -1282,16 +1286,20 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::select_first_device_unconditiona
 }
 
 bool PhysicalDevice::has_dedicated_compute_queue() const {
-	return detail::get_dedicated_queue_index(queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	return detail::get_dedicated_queue_index(queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) !=
+	       detail::QUEUE_INDEX_MAX_VALUE;
 }
 bool PhysicalDevice::has_separate_compute_queue() const {
-	return detail::get_separate_queue_index(queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	return detail::get_separate_queue_index(queue_families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT) !=
+	       detail::QUEUE_INDEX_MAX_VALUE;
 }
 bool PhysicalDevice::has_dedicated_transfer_queue() const {
-	return detail::get_dedicated_queue_index(queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	return detail::get_dedicated_queue_index(queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) !=
+	       detail::QUEUE_INDEX_MAX_VALUE;
 }
 bool PhysicalDevice::has_separate_transfer_queue() const {
-	return detail::get_separate_queue_index(queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) != detail::QUEUE_INDEX_MAX_VALUE;
+	return detail::get_separate_queue_index(queue_families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT) !=
+	       detail::QUEUE_INDEX_MAX_VALUE;
 }
 std::vector<VkQueueFamilyProperties> PhysicalDevice::get_queue_families() const {
 	return queue_families;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -614,8 +614,13 @@ void destroy_swapchain(Swapchain const& swapchain);
 
 class SwapchainBuilder {
 	public:
+    // Construct a SwapchainBuilder with a `vkb::Device`
 	explicit SwapchainBuilder(Device const& device);
-	explicit SwapchainBuilder(Device const& device, VkSurfaceKHR const surface);
+	// Construct a SwapchainBuilder with a specific VkSurfaceKHR handle and `vkb::Device`
+    explicit SwapchainBuilder(Device const& device, VkSurfaceKHR const surface);
+    // Construct a SwapchainBuilder with Vulkan handles for the physical device, device, and surface
+    // Optionally can provide the uint32_t indices for the graphics and present queue
+    // Note: The constructor will query the graphics & present queue if the indices are not provided
 	explicit SwapchainBuilder(VkPhysicalDevice const physical_device,
 	    VkDevice const device,
 	    VkSurfaceKHR const surface,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(vk-bootstrap-test main.cpp bootstrap_tests.cpp error_code_tests.cpp)
+add_executable(vk-bootstrap-test main.cpp bootstrap_tests.cpp error_code_tests.cpp unit_tests.cpp)
 target_link_libraries(vk-bootstrap-test
     PRIVATE
     vk-bootstrap

--- a/tests/common.h
+++ b/tests/common.h
@@ -88,6 +88,7 @@ struct VulkanLibrary {
 
 	void init(VkInstance instance) {
 		vkGetDeviceProcAddr = (PFN_vkGetDeviceProcAddr)vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr");
+		vkDestroySurfaceKHR = (PFN_vkDestroySurfaceKHR)vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR");
 	}
 
 	void init(VkDevice device) {
@@ -125,7 +126,6 @@ struct VulkanLibrary {
 		vkDestroyPipeline = (PFN_vkDestroyPipeline)vkGetDeviceProcAddr(device, "vkDestroyPipeline");
 		vkDestroyPipelineLayout =
 		    (PFN_vkDestroyPipelineLayout)vkGetDeviceProcAddr(device, "vkDestroyPipelineLayout");
-		vkDestroySurfaceKHR = (PFN_vkDestroySurfaceKHR)vkGetDeviceProcAddr(device, "vkDestroySurfaceKHR");
         vkDestroyRenderPass = (PFN_vkDestroyRenderPass)vkGetDeviceProcAddr(device, "vkDestroyRenderPass");
     }
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch.hpp>
+
+#include "VkBootstrap.cpp"
+
+
+TEST_CASE("Single Queue Device", "[UnitTests.queue_selection_logic]") {
+	std::vector<VkQueueFamilyProperties> families = { VkQueueFamilyProperties{
+		VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } } };
+
+	REQUIRE(0 == vkb::detail::get_first_queue_index(families, VK_QUEUE_GRAPHICS_BIT));
+	REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+	        vkb::detail::get_separate_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+	REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+	        vkb::detail::get_separate_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+	REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+	        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+	REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+	        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+}
+
+TEST_CASE("Dedicated Compute Queue, Separate Transfer", "[UnitTests.queue_selection_logic]") {
+	SECTION("Dedicated Queue First") {
+		std::vector<VkQueueFamilyProperties> families = {
+			VkQueueFamilyProperties{
+			    VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } }
+		};
+
+		REQUIRE(0 == vkb::detail::get_first_queue_index(families, VK_QUEUE_GRAPHICS_BIT));
+		REQUIRE(1 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(2 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+		REQUIRE(1 == vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+		        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+	}
+	SECTION("Dedicated Queue Last") {
+		std::vector<VkQueueFamilyProperties> families = {
+			VkQueueFamilyProperties{
+			    VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } }
+		};
+
+		REQUIRE(0 == vkb::detail::get_first_queue_index(families, VK_QUEUE_GRAPHICS_BIT));
+		REQUIRE(2 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(1 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+		REQUIRE(2 == vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+		        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+	}
+}
+
+TEST_CASE("Dedicated Transfer Queue, Separate Compute", "[UnitTests.queue_selection_logic]") {
+	SECTION("Dedicated Queue First") {
+		std::vector<VkQueueFamilyProperties> families = {
+			VkQueueFamilyProperties{
+			    VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } }
+		};
+
+		REQUIRE(0 == vkb::detail::get_first_queue_index(families, VK_QUEUE_GRAPHICS_BIT));
+		REQUIRE(2 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(1 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+		REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+		        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(1 == vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+	}
+	SECTION("Dedicated Queue Last") {
+		std::vector<VkQueueFamilyProperties> families = {
+			VkQueueFamilyProperties{
+			    VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } },
+			VkQueueFamilyProperties{ VK_QUEUE_TRANSFER_BIT, 1, 0, VkExtent3D{ 1, 1, 1 } }
+		};
+
+		REQUIRE(0 == vkb::detail::get_first_queue_index(families, VK_QUEUE_GRAPHICS_BIT));
+		REQUIRE(1 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(2 == vkb::detail::get_separate_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+		REQUIRE(vkb::detail::QUEUE_INDEX_MAX_VALUE ==
+		        vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT));
+		REQUIRE(2 == vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
+	}
+}
+
+TEST_CASE("Queue Selection logic", "[VkBootstrap.queue_logic]") {
+	vkb::InstanceBuilder builder;
+
+	auto instance_ret = builder.request_validation_layers().build();
+	REQUIRE(instance_ret.has_value());
+
+	vkb::destroy_instance(instance_ret.value());
+}

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -83,12 +83,3 @@ TEST_CASE("Dedicated Transfer Queue, Separate Compute", "[UnitTests.queue_select
 		REQUIRE(2 == vkb::detail::get_dedicated_queue_index(families, VK_QUEUE_TRANSFER_BIT, VK_QUEUE_COMPUTE_BIT));
 	}
 }
-
-TEST_CASE("Queue Selection logic", "[VkBootstrap.queue_logic]") {
-	vkb::InstanceBuilder builder;
-
-	auto instance_ret = builder.request_validation_layers().build();
-	REQUIRE(instance_ret.has_value());
-
-	vkb::destroy_instance(instance_ret.value());
-}


### PR DESCRIPTION
Additionally adds comments on the constructors for SwapchainBuilder and resolves the TODO of when the swapchain builder constructor fails to get the queue indices.

Fixes #71 