### PR TITLE
Allow setting pUserData in Debug Messenger, move default callback to header file.

### DIFF
--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -3,11 +3,8 @@
 #include <catch2/catch.hpp>
 
 vkb::Instance get_instance(uint32_t minor_version = 0) {
-	auto instance_ret = vkb::InstanceBuilder()
-	                        .request_validation_layers()
-	                        .require_api_version(1, minor_version)
-	                        .use_default_debug_messenger()
-	                        .build();
+	auto instance_ret =
+	    vkb::InstanceBuilder().request_validation_layers().require_api_version(1, minor_version).build();
 	REQUIRE(instance_ret.has_value());
 	return instance_ret.value();
 }
@@ -16,7 +13,6 @@ vkb::Instance get_headless_instance(uint32_t minor_version = 0) {
 	                        .request_validation_layers()
 	                        .require_api_version(1, minor_version)
 	                        .set_headless()
-	                        .use_default_debug_messenger()
 	                        .build();
 	REQUIRE(instance_ret.has_value());
 	return instance_ret.value();


### PR DESCRIPTION
The vulkan-loader implements the debug utils extension and always makes it available.
So this change makes it so that vk-bootstrap will always enable the extension and setup a
debug callback.

In addition, it is now possible to set pUserData if the user desires, which is nice for
custom debug callbacks

Lastly, the location of the default debug messenger function is now in the header file,
which makes it easier to find and possibly edit.