### PR TITLE
Avoid loading global libvulkan.dylib in macos

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -64,8 +64,7 @@ class VulkanFunctions {
 			library = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
 			if (!library) library = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
 #elif defined(__APPLE__)
-			library = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
-			if (!library) library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+			library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 #elif defined(_WIN32)
 			library = LoadLibrary(TEXT("vulkan-1.dll"));
 #else


### PR DESCRIPTION
dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL) was loading the dylib from outside the app bundle when the SDK was installed. And in macos libvulkan.1.dylib is the one that gets distributed in a bundled app.

This will avoid conflicts between the bundled and distributed vulkan dependencies.

This PR fixes this issue https://github.com/charles-lunarg/vk-bootstrap/issues/83