### PR TITLE
fix minor typos and duplicate include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ project(VulkanBootstrap)
 
 option(VK_BOOTSTRAP_WERROR "Enable warnings as errors during compilation" OFF)
 
-add_library(vk-boostrap-vulkan-headers INTERFACE)
+add_library(vk-bootstrap-vulkan-headers INTERFACE)
 
 set(VK_BOOTSTRAP_VULKAN_HEADER_DIR "" CACHE STRING "Specify the location of the Vulkan-Headers include directory.")
 mark_as_advanced(VK_BOOTSTRAP_VULKAN_HEADER_DIR)
 
 if(NOT "${VK_BOOTSTRAP_VULKAN_HEADER_DIR}" STREQUAL "")
-  target_include_directories(vk-boostrap-vulkan-headers INTERFACE ${VK_BOOTSTRAP_VULKAN_HEADER_DIR})
+  target_include_directories(vk-bootstrap-vulkan-headers INTERFACE $<BUILD_INTERFACE:${VK_BOOTSTRAP_VULKAN_HEADER_DIR}>)
 else ()
   find_package(Vulkan QUIET)
 
@@ -21,9 +21,9 @@ else ()
           GIT_TAG        v1.2.171
       )
       FetchContent_MakeAvailable(VulkanHeaders)
-      target_link_libraries(vk-boostrap-vulkan-headers INTERFACE Vulkan::Headers)
+      target_link_libraries(vk-bootstrap-vulkan-headers INTERFACE Vulkan::Headers)
   else()
-      set_target_properties(vk-boostrap-vulkan-headers PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${Vulkan_INCLUDE_DIR})
+      set_target_properties(vk-bootstrap-vulkan-headers PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${Vulkan_INCLUDE_DIR})
   endif()
 endif()
 
@@ -64,11 +64,10 @@ endif()
 target_include_directories(vk-bootstrap PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>)
-target_include_directories(vk-bootstrap PUBLIC src)
 target_link_libraries(vk-bootstrap
         PRIVATE
         vk-bootstrap-compiler-warnings
-        vk-boostrap-vulkan-headers
+        vk-bootstrap-vulkan-headers
         ${CMAKE_DL_LIBS})
 target_compile_features(vk-bootstrap PUBLIC cxx_std_14)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(vk-bootstrap-triangle
         glfw
         vk-bootstrap
         vk-bootstrap-compiler-warnings
-        vk-boostrap-vulkan-headers)
+        vk-bootstrap-vulkan-headers)
 target_include_directories(vk-bootstrap-triangle PRIVATE ${CMAKE_CURRENT_BINARY_DIR}) #path to build directory for shaders
 
 add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(vk-bootstrap-test main.cpp bootstrap_tests.cpp error_code_tests.c
 target_link_libraries(vk-bootstrap-test
     PRIVATE
     vk-bootstrap
-    vk-boostrap-vulkan-headers
+    vk-bootstrap-vulkan-headers
     vk-bootstrap-compiler-warnings
     glfw
     Catch2


### PR DESCRIPTION
This is just a minor change to use vk-bootstrap with an install(export) setup in cmake.
The added "src" include path would contain CMAKE_SOURCE_DIR and that causes an error
message as it could not be exported into a cmake target config file.
