### PR TITLE
Only add physical device properties 2 extension if using Vulkan 1.0

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -615,7 +615,8 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	}
 	bool supports_properties2_ext = detail::check_extension_supported(
 	    system.available_extensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-	if (supports_properties2_ext) {
+		
+	if (supports_properties2_ext && api_version < VK_API_VERSION_1_1) {
 		extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 


### PR DESCRIPTION
As noted [here](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_get_physical_device_properties2.html#_deprecation_state), the extension's functionality is already part of Vulkan 1.1 Core. The rest of the work of using the structs/functions from Vulkan 1.1 Core seems to have been done already.