### PR TITLE
Add InstanceBuilder functions for setting the different versions dire…

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -749,16 +749,32 @@ InstanceBuilder& InstanceBuilder::set_engine_name(const char* engine_name) {
 	info.engine_name = engine_name;
 	return *this;
 }
+InstanceBuilder& InstanceBuilder::set_app_version(uint32_t app_version) {
+	info.application_version = app_version;
+	return *this;
+}
 InstanceBuilder& InstanceBuilder::set_app_version(uint32_t major, uint32_t minor, uint32_t patch) {
 	info.application_version = VK_MAKE_VERSION(major, minor, patch);
+	return *this;
+}
+InstanceBuilder& InstanceBuilder::set_engine_version(uint32_t engine_version) {
+	info.engine_version = engine_version;
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::set_engine_version(uint32_t major, uint32_t minor, uint32_t patch) {
 	info.engine_version = VK_MAKE_VERSION(major, minor, patch);
 	return *this;
 }
+InstanceBuilder& InstanceBuilder::require_api_version(uint32_t required_api_version) {
+	info.required_api_version = required_api_version;
+	return *this;
+}
 InstanceBuilder& InstanceBuilder::require_api_version(uint32_t major, uint32_t minor, uint32_t patch) {
 	info.required_api_version = VK_MAKE_VERSION(major, minor, patch);
+	return *this;
+}
+InstanceBuilder& InstanceBuilder::desire_api_version(uint32_t preferred_vulkan_version) {
+	info.desired_api_version = preferred_vulkan_version;
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::desire_api_version(uint32_t major, uint32_t minor, uint32_t patch) {

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -290,12 +290,28 @@ class InstanceBuilder {
 	InstanceBuilder& set_app_name(const char* app_name);
 	// Sets the name of the engine. Defaults to "" if none is provided.
 	InstanceBuilder& set_engine_name(const char* engine_name);
+
+	// Sets the version of the application.
+	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	InstanceBuilder& set_app_version(uint32_t app_version);
 	// Sets the (major, minor, patch) version of the application.
 	InstanceBuilder& set_app_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
+
+	// Sets the version of the engine.
+	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	InstanceBuilder& set_engine_version(uint32_t engine_version);
 	// Sets the (major, minor, patch) version of the engine.
 	InstanceBuilder& set_engine_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
+
+	// Require a vulkan instance API version. Will fail to create if this version isn't available.
+	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	InstanceBuilder& require_api_version(uint32_t required_api_version);
 	// Require a vulkan instance API version. Will fail to create if this version isn't available.
 	InstanceBuilder& require_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
+
+	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the highest version available.
+	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	InstanceBuilder& desire_api_version(uint32_t preferred_vulkan_version);
 	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the highest version available.
 	InstanceBuilder& desire_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
 


### PR DESCRIPTION
When wanting to store the application version or api version for usage with other tools and/or SDKs, it's annoying to destruct the version to let vk-bootstrap construct it again. It was probably done this way so that new users don't just pass `1` into the function, however there is no massive issue in doing so (except for API version) and it is a pain having this amount of boilerplate (which this lib is trying to remove):
```cpp
instanceBuilder.set_app_version(
    VK_API_VERSION_MAJOR(appVersion),
    VK_API_VERSION_MINOR(appVersion),
    VK_API_VERSION_PATCH(appVersion));
```