### PR TITLE
Vulkan 1.1 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ install(TARGETS vk-bootstrap
 
 option(VK_BOOTSTRAP_TEST "Test Vk-Bootstrap with glfw and Catch2" OFF)
 
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR VK_BOOTSTRAP_TEST)
+if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${VK_BOOTSTRAP_TEST})
 
     add_subdirectory(ext)
     add_subdirectory(tests)

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -519,9 +519,13 @@ SystemInfo::SystemInfo() {
 		    detail::vulkan_functions().fp_vkEnumerateInstanceExtensionProperties,
 		    layer.layerName);
 		if (layer_extensions_ret == VK_SUCCESS) {
-			for (auto& ext : layer_extensions)
-				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0)
+			for (auto& ext : layer_extensions) {
+				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
 					debug_utils_available = true;
+				}
+			}
+			this->available_extensions.insert(
+			    this->available_extensions.end(), layer_extensions.begin(), layer_extensions.end());
 		}
 	}
 }

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -3171,7 +3171,7 @@ struct DispatchTable {
 #if (defined(VK_NVX_image_view_handle))
 	PFN_vkGetImageViewHandleNVX fp_vkGetImageViewHandleNVX = nullptr;
 #endif
-#if (defined(VK_NVX_image_view_handle))
+#if (defined(VK_NVX_image_view_handle) && VK_NVX_IMAGE_VIEW_HANDLE_SPEC_VERSION == 2)
 	PFN_vkGetImageViewAddressNVX fp_vkGetImageViewAddressNVX = nullptr;
 #endif
 #if (defined(VK_EXT_full_screen_exclusive) && defined(VK_KHR_device_group)) || (defined(VK_EXT_full_screen_exclusive) && defined(VK_VERSION_1_1))

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -2063,7 +2063,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	VkDeviceAddress getBufferDeviceAddress(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
+	VkDeviceAddress getBufferDeviceAddress(const VkBufferDeviceAddressInfoEXT* pInfo) const noexcept {
 		return fp_vkGetBufferDeviceAddress(device, pInfo);
 	}
 #endif

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -2022,7 +2022,7 @@ struct DispatchTable {
 		return fp_vkGetImageViewHandleNVX(device, pInfo);
 	}
 #endif
-#if (defined(VK_NVX_image_view_handle))
+#if (defined(VK_NVX_image_view_handle) && VK_NVX_IMAGE_VIEW_HANDLE_SPEC_VERSION == 2)
 	VkResult getImageViewAddressNVX(VkImageView imageView, VkImageViewAddressPropertiesNVX* pProperties) const noexcept {
 		return fp_vkGetImageViewAddressNVX(device, imageView, pProperties);
 	}

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -1908,7 +1908,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_NV_ray_tracing))
-	void cmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkCopyAccelerationStructureModeKHR mode) const noexcept {
+	void cmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkCopyAccelerationStructureModeNV mode) const noexcept {
 		fp_vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
 	}
 #endif

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -1783,12 +1783,12 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
-	VkResult getAndroidHardwareBufferPropertiesANDROID(AHardwareBuffer buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) const noexcept {
+	VkResult getAndroidHardwareBufferPropertiesANDROID(AHardwareBuffer* buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) const noexcept {
 		return fp_vkGetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties);
 	}
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
-	VkResult getMemoryAndroidHardwareBufferANDROID(const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, AHardwareBuffer pBuffer) const noexcept {
+	VkResult getMemoryAndroidHardwareBufferANDROID(const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, AHardwareBuffer** pBuffer) const noexcept {
 		return fp_vkGetMemoryAndroidHardwareBufferANDROID(device, pInfo, pBuffer);
 	}
 #endif

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -61,7 +61,7 @@ struct DispatchTable {
 		fp_vkDestroyQueryPool = (PFN_vkDestroyQueryPool)procAddr(device, "vkDestroyQueryPool");
 		fp_vkGetQueryPoolResults = (PFN_vkGetQueryPoolResults)procAddr(device, "vkGetQueryPoolResults");
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_host_query_reset))
-		fp_vkResetQueryPool = (PFN_vkResetQueryPool)procAddr(device, "vkResetQueryPool");
+		fp_vkResetQueryPool = (PFN_vkResetQueryPool)procAddr(device, "vkResetQueryPoolEXT");
 #endif
 		fp_vkCreateBuffer = (PFN_vkCreateBuffer)procAddr(device, "vkCreateBuffer");
 		fp_vkDestroyBuffer = (PFN_vkDestroyBuffer)procAddr(device, "vkDestroyBuffer");
@@ -418,25 +418,25 @@ struct DispatchTable {
 		fp_vkCmdWriteBufferMarkerAMD = (PFN_vkCmdWriteBufferMarkerAMD)procAddr(device, "vkCmdWriteBufferMarkerAMD");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCreateRenderPass2 = (PFN_vkCreateRenderPass2)procAddr(device, "vkCreateRenderPass2");
+		fp_vkCreateRenderPass2 = (PFN_vkCreateRenderPass2)procAddr(device, "vkCreateRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdBeginRenderPass2 = (PFN_vkCmdBeginRenderPass2)procAddr(device, "vkCmdBeginRenderPass2");
+		fp_vkCmdBeginRenderPass2 = (PFN_vkCmdBeginRenderPass2)procAddr(device, "vkCmdBeginRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdNextSubpass2 = (PFN_vkCmdNextSubpass2)procAddr(device, "vkCmdNextSubpass2");
+		fp_vkCmdNextSubpass2 = (PFN_vkCmdNextSubpass2)procAddr(device, "vkCmdNextSubpass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdEndRenderPass2 = (PFN_vkCmdEndRenderPass2)procAddr(device, "vkCmdEndRenderPass2");
+		fp_vkCmdEndRenderPass2 = (PFN_vkCmdEndRenderPass2)procAddr(device, "vkCmdEndRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkGetSemaphoreCounterValue = (PFN_vkGetSemaphoreCounterValue)procAddr(device, "vkGetSemaphoreCounterValue");
+		fp_vkGetSemaphoreCounterValue = (PFN_vkGetSemaphoreCounterValue)procAddr(device, "vkGetSemaphoreCounterValueKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkWaitSemaphores = (PFN_vkWaitSemaphores)procAddr(device, "vkWaitSemaphores");
+		fp_vkWaitSemaphores = (PFN_vkWaitSemaphores)procAddr(device, "vkWaitSemaphoresKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkSignalSemaphore = (PFN_vkSignalSemaphore)procAddr(device, "vkSignalSemaphore");
+		fp_vkSignalSemaphore = (PFN_vkSignalSemaphore)procAddr(device, "vkSignalSemaphoreKHR");
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
 		fp_vkGetAndroidHardwareBufferPropertiesANDROID = (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)procAddr(device, "vkGetAndroidHardwareBufferPropertiesANDROID");
@@ -445,10 +445,10 @@ struct DispatchTable {
 		fp_vkGetMemoryAndroidHardwareBufferANDROID = (PFN_vkGetMemoryAndroidHardwareBufferANDROID)procAddr(device, "vkGetMemoryAndroidHardwareBufferANDROID");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-		fp_vkCmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCount)procAddr(device, "vkCmdDrawIndirectCount");
+		fp_vkCmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCount)procAddr(device, "vkCmdDrawIndirectCountAMD");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-		fp_vkCmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCount)procAddr(device, "vkCmdDrawIndexedIndirectCount");
+		fp_vkCmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCount)procAddr(device, "vkCmdDrawIndexedIndirectCountAMD");
 #endif
 #if (defined(VK_NV_device_diagnostic_checkpoints))
 		fp_vkCmdSetCheckpointNV = (PFN_vkCmdSetCheckpointNV)procAddr(device, "vkCmdSetCheckpointNV");
@@ -604,10 +604,10 @@ struct DispatchTable {
 		fp_vkGetImageDrmFormatModifierPropertiesEXT = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)procAddr(device, "vkGetImageDrmFormatModifierPropertiesEXT");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-		fp_vkGetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddress)procAddr(device, "vkGetBufferOpaqueCaptureAddress");
+		fp_vkGetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddress)procAddr(device, "vkGetBufferOpaqueCaptureAddressKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)procAddr(device, "vkGetBufferDeviceAddress");
+		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)procAddr(device, "vkGetBufferDeviceAddressKHR");
 #endif
 #if (defined(VK_INTEL_performance_query))
 		fp_vkInitializePerformanceApiINTEL = (PFN_vkInitializePerformanceApiINTEL)procAddr(device, "vkInitializePerformanceApiINTEL");
@@ -637,7 +637,7 @@ struct DispatchTable {
 		fp_vkGetPerformanceParameterINTEL = (PFN_vkGetPerformanceParameterINTEL)procAddr(device, "vkGetPerformanceParameterINTEL");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-		fp_vkGetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)procAddr(device, "vkGetDeviceMemoryOpaqueCaptureAddress");
+		fp_vkGetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)procAddr(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
 #endif
 #if (defined(VK_KHR_pipeline_executable_properties))
 		fp_vkGetPipelineExecutablePropertiesKHR = (PFN_vkGetPipelineExecutablePropertiesKHR)procAddr(device, "vkGetPipelineExecutablePropertiesKHR");
@@ -1748,22 +1748,22 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	VkResult createRenderPass2(const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const noexcept {
+	VkResult createRenderPass2(const VkRenderPassCreateInfo2KHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const noexcept {
 		return fp_vkCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfo* pSubpassBeginInfo) const noexcept {
+	void cmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfoKHR* pSubpassBeginInfo) const noexcept {
 		fp_vkCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo, const VkSubpassEndInfo* pSubpassEndInfo) const noexcept {
+	void cmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfoKHR* pSubpassBeginInfo, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
 		fp_vkCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const noexcept {
+	void cmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
 		fp_vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
 	}
 #endif
@@ -1773,12 +1773,12 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	VkResult waitSemaphores(const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout) const noexcept {
+	VkResult waitSemaphores(const VkSemaphoreWaitInfoKHR* pWaitInfo, uint64_t timeout) const noexcept {
 		return fp_vkWaitSemaphores(device, pWaitInfo, timeout);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	VkResult signalSemaphore(const VkSemaphoreSignalInfo* pSignalInfo) const noexcept {
+	VkResult signalSemaphore(const VkSemaphoreSignalInfoKHR* pSignalInfo) const noexcept {
 		return fp_vkSignalSemaphore(device, pSignalInfo);
 	}
 #endif
@@ -2058,12 +2058,12 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	uint64_t getBufferOpaqueCaptureAddress(const VkBufferDeviceAddressInfo* pInfo) const noexcept {
+	uint64_t getBufferOpaqueCaptureAddress(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetBufferOpaqueCaptureAddress(device, pInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	VkDeviceAddress getBufferDeviceAddress(const VkBufferDeviceAddressInfo* pInfo) const noexcept {
+	VkDeviceAddress getBufferDeviceAddress(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetBufferDeviceAddress(device, pInfo);
 	}
 #endif
@@ -2113,7 +2113,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	uint64_t getDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) const noexcept {
+	uint64_t getDeviceMemoryOpaqueCaptureAddress(const VkDeviceMemoryOpaqueCaptureAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetDeviceMemoryOpaqueCaptureAddress(device, pInfo);
 	}
 #endif
@@ -2553,22 +2553,22 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	VkResult createRenderPass2KHR(const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const noexcept {
+	VkResult createRenderPass2KHR(const VkRenderPassCreateInfo2KHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const noexcept {
 		return fp_vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfo* pSubpassBeginInfo) const noexcept {
+	void cmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfoKHR* pSubpassBeginInfo) const noexcept {
 		fp_vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo, const VkSubpassEndInfo* pSubpassEndInfo) const noexcept {
+	void cmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfoKHR* pSubpassBeginInfo, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
 		fp_vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	void cmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const noexcept {
+	void cmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
 		fp_vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
 	}
 #endif
@@ -2578,12 +2578,12 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	VkResult waitSemaphoresKHR(const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout) const noexcept {
+	VkResult waitSemaphoresKHR(const VkSemaphoreWaitInfoKHR* pWaitInfo, uint64_t timeout) const noexcept {
 		return fp_vkWaitSemaphoresKHR(device, pWaitInfo, timeout);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	VkResult signalSemaphoreKHR(const VkSemaphoreSignalInfo* pSignalInfo) const noexcept {
+	VkResult signalSemaphoreKHR(const VkSemaphoreSignalInfoKHR* pSignalInfo) const noexcept {
 		return fp_vkSignalSemaphoreKHR(device, pSignalInfo);
 	}
 #endif
@@ -2603,17 +2603,17 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	uint64_t getBufferOpaqueCaptureAddressKHR(const VkBufferDeviceAddressInfo* pInfo) const noexcept {
+	uint64_t getBufferOpaqueCaptureAddressKHR(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetBufferOpaqueCaptureAddressKHR(device, pInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	VkDeviceAddress getBufferDeviceAddressEXT(const VkBufferDeviceAddressInfo* pInfo) const noexcept {
+	VkDeviceAddress getBufferDeviceAddressEXT(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetBufferDeviceAddressEXT(device, pInfo);
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	uint64_t getDeviceMemoryOpaqueCaptureAddressKHR(const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) const noexcept {
+	uint64_t getDeviceMemoryOpaqueCaptureAddressKHR(const VkDeviceMemoryOpaqueCaptureAddressInfoKHR* pInfo) const noexcept {
 		return fp_vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo);
 	}
 #endif

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -607,7 +607,7 @@ struct DispatchTable {
 		fp_vkGetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddressKHR)procAddr(device, "vkGetBufferOpaqueCaptureAddressKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddressKHR)procAddr(device, "vkGetBufferDeviceAddressKHR");
+		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddressEXT)procAddr(device, "vkGetBufferDeviceAddressEXT");
 #endif
 #if (defined(VK_INTEL_performance_query))
 		fp_vkInitializePerformanceApiINTEL = (PFN_vkInitializePerformanceApiINTEL)procAddr(device, "vkInitializePerformanceApiINTEL");
@@ -2608,7 +2608,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	VkDeviceAddress getBufferDeviceAddressEXT(const VkBufferDeviceAddressInfoKHR* pInfo) const noexcept {
+	VkDeviceAddress getBufferDeviceAddressEXT(const VkBufferDeviceAddressInfoEXT* pInfo) const noexcept {
 		return fp_vkGetBufferDeviceAddressEXT(device, pInfo);
 	}
 #endif
@@ -3196,7 +3196,7 @@ struct DispatchTable {
 	PFN_vkGetBufferOpaqueCaptureAddressKHR fp_vkGetBufferOpaqueCaptureAddress = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	PFN_vkGetBufferDeviceAddressKHR fp_vkGetBufferDeviceAddress = nullptr;
+	PFN_vkGetBufferDeviceAddressEXT fp_vkGetBufferDeviceAddress = nullptr;
 #endif
 #if (defined(VK_INTEL_performance_query))
 	PFN_vkInitializePerformanceApiINTEL fp_vkInitializePerformanceApiINTEL = nullptr;

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -552,7 +552,7 @@ struct DispatchTable {
 #if (defined(VK_NV_ray_tracing))
 		fp_vkCmdTraceRaysNV = (PFN_vkCmdTraceRaysNV)procAddr(device, "vkCmdTraceRaysNV");
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
+#if (defined(VK_KHR_ray_tracing_pipeline))
 		fp_vkGetRayTracingShaderGroupHandlesKHR = (PFN_vkGetRayTracingShaderGroupHandlesKHR)procAddr(device, "vkGetRayTracingShaderGroupHandlesKHR");
 #endif
 #if (defined(VK_KHR_ray_tracing_pipeline))
@@ -927,7 +927,7 @@ struct DispatchTable {
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
 		fp_vkCmdDrawIndexedIndirectCountAMD = (PFN_vkCmdDrawIndexedIndirectCountAMD)procAddr(device, "vkCmdDrawIndexedIndirectCountAMD");
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
+#if (defined(VK_NV_ray_tracing))
 		fp_vkGetRayTracingShaderGroupHandlesNV = (PFN_vkGetRayTracingShaderGroupHandlesNV)procAddr(device, "vkGetRayTracingShaderGroupHandlesNV");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
@@ -1972,7 +1972,7 @@ struct DispatchTable {
 		fp_vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
 	}
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
+#if (defined(VK_KHR_ray_tracing_pipeline))
 	VkResult getRayTracingShaderGroupHandlesKHR(VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) const noexcept {
 		return fp_vkGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 	}
@@ -2597,7 +2597,7 @@ struct DispatchTable {
 		fp_vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 	}
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
+#if (defined(VK_NV_ray_tracing))
 	VkResult getRayTracingShaderGroupHandlesNV(VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) const noexcept {
 		return fp_vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
 	}
@@ -3141,8 +3141,8 @@ struct DispatchTable {
 #if (defined(VK_NV_ray_tracing))
 	PFN_vkCmdTraceRaysNV fp_vkCmdTraceRaysNV = nullptr;
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
-	PFN_vkGetRayTracingShaderGroupHandlesNV fp_vkGetRayTracingShaderGroupHandlesNV = nullptr;
+#if (defined(VK_KHR_ray_tracing_pipeline))
+	PFN_vkGetRayTracingShaderGroupHandlesKHR fp_vkGetRayTracingShaderGroupHandlesKHR = nullptr;
 #endif
 #if (defined(VK_KHR_ray_tracing_pipeline))
 	PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR fp_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR = nullptr;
@@ -3516,7 +3516,7 @@ struct DispatchTable {
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
 	PFN_vkCmdDrawIndexedIndirectCountAMD fp_vkCmdDrawIndexedIndirectCountAMD = nullptr;
 #endif
-#if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
+#if (defined(VK_NV_ray_tracing))
 	PFN_vkGetRayTracingShaderGroupHandlesNV fp_vkGetRayTracingShaderGroupHandlesNV = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -61,7 +61,7 @@ struct DispatchTable {
 		fp_vkDestroyQueryPool = (PFN_vkDestroyQueryPool)procAddr(device, "vkDestroyQueryPool");
 		fp_vkGetQueryPoolResults = (PFN_vkGetQueryPoolResults)procAddr(device, "vkGetQueryPoolResults");
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_host_query_reset))
-		fp_vkResetQueryPool = (PFN_vkResetQueryPool)procAddr(device, "vkResetQueryPoolEXT");
+		fp_vkResetQueryPool = (PFN_vkResetQueryPoolEXT)procAddr(device, "vkResetQueryPoolEXT");
 #endif
 		fp_vkCreateBuffer = (PFN_vkCreateBuffer)procAddr(device, "vkCreateBuffer");
 		fp_vkDestroyBuffer = (PFN_vkDestroyBuffer)procAddr(device, "vkDestroyBuffer");
@@ -418,25 +418,25 @@ struct DispatchTable {
 		fp_vkCmdWriteBufferMarkerAMD = (PFN_vkCmdWriteBufferMarkerAMD)procAddr(device, "vkCmdWriteBufferMarkerAMD");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCreateRenderPass2 = (PFN_vkCreateRenderPass2)procAddr(device, "vkCreateRenderPass2KHR");
+		fp_vkCreateRenderPass2 = (PFN_vkCreateRenderPass2KHR)procAddr(device, "vkCreateRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdBeginRenderPass2 = (PFN_vkCmdBeginRenderPass2)procAddr(device, "vkCmdBeginRenderPass2KHR");
+		fp_vkCmdBeginRenderPass2 = (PFN_vkCmdBeginRenderPass2KHR)procAddr(device, "vkCmdBeginRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdNextSubpass2 = (PFN_vkCmdNextSubpass2)procAddr(device, "vkCmdNextSubpass2KHR");
+		fp_vkCmdNextSubpass2 = (PFN_vkCmdNextSubpass2KHR)procAddr(device, "vkCmdNextSubpass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-		fp_vkCmdEndRenderPass2 = (PFN_vkCmdEndRenderPass2)procAddr(device, "vkCmdEndRenderPass2KHR");
+		fp_vkCmdEndRenderPass2 = (PFN_vkCmdEndRenderPass2KHR)procAddr(device, "vkCmdEndRenderPass2KHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkGetSemaphoreCounterValue = (PFN_vkGetSemaphoreCounterValue)procAddr(device, "vkGetSemaphoreCounterValueKHR");
+		fp_vkGetSemaphoreCounterValue = (PFN_vkGetSemaphoreCounterValueKHR)procAddr(device, "vkGetSemaphoreCounterValueKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkWaitSemaphores = (PFN_vkWaitSemaphores)procAddr(device, "vkWaitSemaphoresKHR");
+		fp_vkWaitSemaphores = (PFN_vkWaitSemaphoresKHR)procAddr(device, "vkWaitSemaphoresKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-		fp_vkSignalSemaphore = (PFN_vkSignalSemaphore)procAddr(device, "vkSignalSemaphoreKHR");
+		fp_vkSignalSemaphore = (PFN_vkSignalSemaphoreKHR)procAddr(device, "vkSignalSemaphoreKHR");
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
 		fp_vkGetAndroidHardwareBufferPropertiesANDROID = (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)procAddr(device, "vkGetAndroidHardwareBufferPropertiesANDROID");
@@ -445,10 +445,10 @@ struct DispatchTable {
 		fp_vkGetMemoryAndroidHardwareBufferANDROID = (PFN_vkGetMemoryAndroidHardwareBufferANDROID)procAddr(device, "vkGetMemoryAndroidHardwareBufferANDROID");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-		fp_vkCmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCount)procAddr(device, "vkCmdDrawIndirectCountAMD");
+		fp_vkCmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCountAMD)procAddr(device, "vkCmdDrawIndirectCountAMD");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-		fp_vkCmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCount)procAddr(device, "vkCmdDrawIndexedIndirectCountAMD");
+		fp_vkCmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCountAMD)procAddr(device, "vkCmdDrawIndexedIndirectCountAMD");
 #endif
 #if (defined(VK_NV_device_diagnostic_checkpoints))
 		fp_vkCmdSetCheckpointNV = (PFN_vkCmdSetCheckpointNV)procAddr(device, "vkCmdSetCheckpointNV");
@@ -604,10 +604,10 @@ struct DispatchTable {
 		fp_vkGetImageDrmFormatModifierPropertiesEXT = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)procAddr(device, "vkGetImageDrmFormatModifierPropertiesEXT");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-		fp_vkGetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddress)procAddr(device, "vkGetBufferOpaqueCaptureAddressKHR");
+		fp_vkGetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddressKHR)procAddr(device, "vkGetBufferOpaqueCaptureAddressKHR");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)procAddr(device, "vkGetBufferDeviceAddressKHR");
+		fp_vkGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddressKHR)procAddr(device, "vkGetBufferDeviceAddressKHR");
 #endif
 #if (defined(VK_INTEL_performance_query))
 		fp_vkInitializePerformanceApiINTEL = (PFN_vkInitializePerformanceApiINTEL)procAddr(device, "vkInitializePerformanceApiINTEL");
@@ -637,7 +637,7 @@ struct DispatchTable {
 		fp_vkGetPerformanceParameterINTEL = (PFN_vkGetPerformanceParameterINTEL)procAddr(device, "vkGetPerformanceParameterINTEL");
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-		fp_vkGetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)procAddr(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
+		fp_vkGetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR)procAddr(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
 #endif
 #if (defined(VK_KHR_pipeline_executable_properties))
 		fp_vkGetPipelineExecutablePropertiesKHR = (PFN_vkGetPipelineExecutablePropertiesKHR)procAddr(device, "vkGetPipelineExecutablePropertiesKHR");
@@ -2650,7 +2650,7 @@ struct DispatchTable {
 	PFN_vkDestroyQueryPool fp_vkDestroyQueryPool = nullptr;
 	PFN_vkGetQueryPoolResults fp_vkGetQueryPoolResults = nullptr;
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_host_query_reset))
-	PFN_vkResetQueryPool fp_vkResetQueryPool = nullptr;
+	PFN_vkResetQueryPoolEXT fp_vkResetQueryPool = nullptr;
 #endif
 	PFN_vkCreateBuffer fp_vkCreateBuffer = nullptr;
 	PFN_vkDestroyBuffer fp_vkDestroyBuffer = nullptr;
@@ -3007,25 +3007,25 @@ struct DispatchTable {
 	PFN_vkCmdWriteBufferMarkerAMD fp_vkCmdWriteBufferMarkerAMD = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	PFN_vkCreateRenderPass2 fp_vkCreateRenderPass2 = nullptr;
+	PFN_vkCreateRenderPass2KHR fp_vkCreateRenderPass2 = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	PFN_vkCmdBeginRenderPass2 fp_vkCmdBeginRenderPass2 = nullptr;
+	PFN_vkCmdBeginRenderPass2KHR fp_vkCmdBeginRenderPass2 = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	PFN_vkCmdNextSubpass2 fp_vkCmdNextSubpass2 = nullptr;
+	PFN_vkCmdNextSubpass2KHR fp_vkCmdNextSubpass2 = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_create_renderpass2))
-	PFN_vkCmdEndRenderPass2 fp_vkCmdEndRenderPass2 = nullptr;
+	PFN_vkCmdEndRenderPass2KHR fp_vkCmdEndRenderPass2 = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	PFN_vkGetSemaphoreCounterValue fp_vkGetSemaphoreCounterValue = nullptr;
+	PFN_vkGetSemaphoreCounterValueKHR fp_vkGetSemaphoreCounterValue = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	PFN_vkWaitSemaphores fp_vkWaitSemaphores = nullptr;
+	PFN_vkWaitSemaphoresKHR fp_vkWaitSemaphores = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_timeline_semaphore))
-	PFN_vkSignalSemaphore fp_vkSignalSemaphore = nullptr;
+	PFN_vkSignalSemaphoreKHR fp_vkSignalSemaphore = nullptr;
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
 	PFN_vkGetAndroidHardwareBufferPropertiesANDROID fp_vkGetAndroidHardwareBufferPropertiesANDROID = nullptr;
@@ -3034,10 +3034,10 @@ struct DispatchTable {
 	PFN_vkGetMemoryAndroidHardwareBufferANDROID fp_vkGetMemoryAndroidHardwareBufferANDROID = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-	PFN_vkCmdDrawIndirectCount fp_vkCmdDrawIndirectCount = nullptr;
+	PFN_vkCmdDrawIndirectCountAMD fp_vkCmdDrawIndirectCount = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_AMD_draw_indirect_count))
-	PFN_vkCmdDrawIndexedIndirectCount fp_vkCmdDrawIndexedIndirectCount = nullptr;
+	PFN_vkCmdDrawIndexedIndirectCountAMD fp_vkCmdDrawIndexedIndirectCount = nullptr;
 #endif
 #if (defined(VK_NV_device_diagnostic_checkpoints))
 	PFN_vkCmdSetCheckpointNV fp_vkCmdSetCheckpointNV = nullptr;
@@ -3193,10 +3193,10 @@ struct DispatchTable {
 	PFN_vkGetImageDrmFormatModifierPropertiesEXT fp_vkGetImageDrmFormatModifierPropertiesEXT = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	PFN_vkGetBufferOpaqueCaptureAddress fp_vkGetBufferOpaqueCaptureAddress = nullptr;
+	PFN_vkGetBufferOpaqueCaptureAddressKHR fp_vkGetBufferOpaqueCaptureAddress = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_EXT_buffer_device_address))
-	PFN_vkGetBufferDeviceAddress fp_vkGetBufferDeviceAddress = nullptr;
+	PFN_vkGetBufferDeviceAddressKHR fp_vkGetBufferDeviceAddress = nullptr;
 #endif
 #if (defined(VK_INTEL_performance_query))
 	PFN_vkInitializePerformanceApiINTEL fp_vkInitializePerformanceApiINTEL = nullptr;
@@ -3226,7 +3226,7 @@ struct DispatchTable {
 	PFN_vkGetPerformanceParameterINTEL fp_vkGetPerformanceParameterINTEL = nullptr;
 #endif
 #if (defined(VK_VERSION_1_2)) || (defined(VK_KHR_buffer_device_address))
-	PFN_vkGetDeviceMemoryOpaqueCaptureAddress fp_vkGetDeviceMemoryOpaqueCaptureAddress = nullptr;
+	PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR fp_vkGetDeviceMemoryOpaqueCaptureAddress = nullptr;
 #endif
 #if (defined(VK_KHR_pipeline_executable_properties))
 	PFN_vkGetPipelineExecutablePropertiesKHR fp_vkGetPipelineExecutablePropertiesKHR = nullptr;

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -3142,7 +3142,7 @@ struct DispatchTable {
 	PFN_vkCmdTraceRaysNV fp_vkCmdTraceRaysNV = nullptr;
 #endif
 #if (defined(VK_KHR_ray_tracing_pipeline)) || (defined(VK_NV_ray_tracing))
-	PFN_vkGetRayTracingShaderGroupHandlesKHR fp_vkGetRayTracingShaderGroupHandlesKHR = nullptr;
+	PFN_vkGetRayTracingShaderGroupHandlesNV fp_vkGetRayTracingShaderGroupHandlesNV = nullptr;
 #endif
 #if (defined(VK_KHR_ray_tracing_pipeline))
 	PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR fp_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR = nullptr;

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -582,7 +582,7 @@ struct DispatchTable {
 #if (defined(VK_NVX_image_view_handle))
 		fp_vkGetImageViewHandleNVX = (PFN_vkGetImageViewHandleNVX)procAddr(device, "vkGetImageViewHandleNVX");
 #endif
-#if (defined(VK_NVX_image_view_handle))
+#if (defined(VK_NVX_image_view_handle) && VK_NVX_IMAGE_VIEW_HANDLE_SPEC_VERSION == 2)
 		fp_vkGetImageViewAddressNVX = (PFN_vkGetImageViewAddressNVX)procAddr(device, "vkGetImageViewAddressNVX");
 #endif
 #if (defined(VK_EXT_full_screen_exclusive) && defined(VK_KHR_device_group)) || (defined(VK_EXT_full_screen_exclusive) && defined(VK_VERSION_1_1))


### PR DESCRIPTION
This PR adds the KHR, EXT, or AMD suffix to VK1.2 types that were promoted from extensions. This lets vk-bookstrap support environments without Vulkan 1.2

This PR enables compatibility with Android NDK 22.0.7026061, the one I'm currently using. Other NDKs with different version of the Vulkan headers might not be compatible. However, as long as the environment has headers for at least Vulkan 1.1 it should be fine (assuming no extensions are at an unexpected revision)

Biggest potential change is that I had to separate our the KHR raytracing extension from the NV raytracing extension. This will hopefully not impact other users of vk-bs