### PR TITLE
Append layer extensions to the list of available extensions

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -519,9 +519,13 @@ SystemInfo::SystemInfo() {
 		    detail::vulkan_functions().fp_vkEnumerateInstanceExtensionProperties,
 		    layer.layerName);
 		if (layer_extensions_ret == VK_SUCCESS) {
-			for (auto& ext : layer_extensions)
-				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0)
+			for (auto& ext : layer_extensions) {
+				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
 					debug_utils_available = true;
+				}
+			}
+			this->available_extensions.insert(
+			    this->available_extensions.end(), layer_extensions.begin(), layer_extensions.end());
 		}
 	}
 }


### PR DESCRIPTION
Append the lists of extensions provided by Vulkan layers to the list of all extensions

This allows you to do things like use `VK_EXT_debug_utils` on Android. My phone's drivers only provide `VK_EXT_debug_report`, `VK_EXT_debug_utils` comes from the validation layer
