### PR TITLE
Fix: Add VkBootstrapDispatch to includable files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else ()
   endif()
 endif()
 
-add_library(vk-bootstrap src/VkBootstrap.h src/VkBootstrap.cpp)
+add_library(vk-bootstrap src/VkBootstrap.h src/VkBootstrap.cpp src/VkBootstrapDispatch.h)
 add_library(vk-bootstrap::vk-bootstrap ALIAS vk-bootstrap)
 
 add_library(vk-bootstrap-compiler-warnings INTERFACE)
@@ -72,7 +72,7 @@ target_link_libraries(vk-bootstrap
 target_compile_features(vk-bootstrap PUBLIC cxx_std_14)
 
 include(GNUInstallDirs)
-install(FILES src/VkBootstrap.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES src/VkBootstrap.h src/VkBootstrapDispatch.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS vk-bootstrap
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
This change seems to be required for this project to work as a [vcpkg port](https://github.com/spnda/vcpkg/tree/master/ports/vk-bootstrap) as it otherwise can't find `VkBootstrapDispatch.h` in any include path. I'm no CMake expert so I'm not quite sure why because this project already does `target_include_directories`, but if it works it works. And I don't think it would break anything else.