### PR TITLE
Make the list of device extensions to enable visible

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1359,7 +1359,7 @@ bool PhysicalDevice::has_separate_transfer_queue() const {
 std::vector<VkQueueFamilyProperties> PhysicalDevice::get_queue_families() const {
 	return queue_families;
 }
-
+std::vector<const char*> PhysicalDevice::get_extensions() const { return extensions_to_enable; }
 PhysicalDevice::operator VkPhysicalDevice() const { return this->physical_device; }
 
 // ---- Queues ---- //

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -435,6 +435,9 @@ struct PhysicalDevice {
 	// Advanced: Get the VkQueueFamilyProperties of the device if special queue setup is needed
 	std::vector<VkQueueFamilyProperties> get_queue_families() const;
 
+	// Query the list of extensions which should be enabled
+	std::vector<const char*> get_extensions() const;
+
 	// A conversion function which allows this PhysicalDevice to be used
 	// in places where VkPhysicalDevice would have been used.
 	operator VkPhysicalDevice() const;


### PR DESCRIPTION
Previously it was difficult to know which extensions were actually enabled.
If an app wanted to optionally enable certain extensions it was hard to know if
they got enabled.