### PR TITLE
Use own Vulkan version macros

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -570,14 +570,14 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	if (!sys_info_ret) return sys_info_ret.error();
 	auto system = sys_info_ret.value();
 
-	uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+	uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
-	if (info.required_api_version > VK_MAKE_VERSION(1, 0, 0) ||
-	    info.desired_api_version > VK_MAKE_VERSION(1, 0, 0)) {
+	if (info.required_api_version > VKB_VK_API_VERSION_1_0 ||
+	    info.desired_api_version > VKB_VK_API_VERSION_1_0) {
 		PFN_vkEnumerateInstanceVersion pfn_vkEnumerateInstanceVersion =
 		    detail::vulkan_functions().fp_vkEnumerateInstanceVersion;
 
-		uint32_t queried_api_version = VK_MAKE_VERSION(1, 0, 0);
+		uint32_t queried_api_version = VKB_VK_API_VERSION_1_0;
 		if (pfn_vkEnumerateInstanceVersion != nullptr) {
 			VkResult res = pfn_vkEnumerateInstanceVersion(&queried_api_version);
 			// Should always return VK_SUCCESS
@@ -592,9 +592,9 @@ detail::Result<Instance> InstanceBuilder::build() const {
 			else
 				return make_error_code(InstanceError::vulkan_version_unavailable);
 		}
-		if (info.required_api_version > VK_MAKE_VERSION(1, 0, 0)) {
+		if (info.required_api_version > VKB_VK_API_VERSION_1_0) {
 			api_version = info.required_api_version;
-		} else if (info.desired_api_version > VK_MAKE_VERSION(1, 0, 0)) {
+		} else if (info.desired_api_version > VKB_VK_API_VERSION_1_0) {
 			if (queried_api_version >= info.desired_api_version)
 				api_version = info.desired_api_version;
 			else
@@ -760,7 +760,7 @@ InstanceBuilder& InstanceBuilder::set_app_version(uint32_t app_version) {
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::set_app_version(uint32_t major, uint32_t minor, uint32_t patch) {
-	info.application_version = VK_MAKE_VERSION(major, minor, patch);
+	info.application_version = VKB_MAKE_VK_VERSION(0, major, minor, patch);
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::set_engine_version(uint32_t engine_version) {
@@ -768,7 +768,7 @@ InstanceBuilder& InstanceBuilder::set_engine_version(uint32_t engine_version) {
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::set_engine_version(uint32_t major, uint32_t minor, uint32_t patch) {
-	info.engine_version = VK_MAKE_VERSION(major, minor, patch);
+	info.engine_version = VKB_MAKE_VK_VERSION(0, major, minor, patch);
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::require_api_version(uint32_t required_api_version) {
@@ -776,7 +776,7 @@ InstanceBuilder& InstanceBuilder::require_api_version(uint32_t required_api_vers
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::require_api_version(uint32_t major, uint32_t minor, uint32_t patch) {
-	info.required_api_version = VK_MAKE_VERSION(major, minor, patch);
+	info.required_api_version = VKB_MAKE_VK_VERSION(0, major, minor, patch);
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::desire_api_version(uint32_t preferred_vulkan_version) {
@@ -784,7 +784,7 @@ InstanceBuilder& InstanceBuilder::desire_api_version(uint32_t preferred_vulkan_v
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::desire_api_version(uint32_t major, uint32_t minor, uint32_t patch) {
-	info.desired_api_version = VK_MAKE_VERSION(major, minor, patch);
+	info.desired_api_version = VKB_MAKE_VK_VERSION(0, major, minor, patch);
 	return *this;
 }
 InstanceBuilder& InstanceBuilder::enable_layer(const char* layer_name) {
@@ -1021,7 +1021,7 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 	detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures(phys_device, &desc.device_features);
 	detail::vulkan_functions().fp_vkGetPhysicalDeviceMemoryProperties(phys_device, &desc.mem_properties);
 
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 #else
 	desc.device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
@@ -1030,7 +1030,7 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 	auto fill_chain = src_extended_features_chain;
 
 	if (!fill_chain.empty() &&
-	    (instance_info.version >= VK_API_VERSION_1_1 || instance_info.supports_properties2_ext)) {
+	    (instance_info.version >= VKB_VK_API_VERSION_1_1 || instance_info.supports_properties2_ext)) {
 
 		detail::GenericFeaturesPNextNode* prev = nullptr;
 		for (auto& extension : fill_chain) {
@@ -1040,8 +1040,8 @@ PhysicalDeviceSelector::PhysicalDeviceDesc PhysicalDeviceSelector::populate_devi
 			prev = &extension;
 		}
 
-#if defined(VK_API_VERSION_1_1)
-		if (instance_info.version >= VK_API_VERSION_1_1 && desc.device_properties.apiVersion >= VK_API_VERSION_1_1) {
+#if defined(VKB_VK_API_VERSION_1_1)
+		if (instance_info.version >= VKB_VK_API_VERSION_1_1 && desc.device_properties.apiVersion >= VKB_VK_API_VERSION_1_1) {
 			VkPhysicalDeviceFeatures2 local_features{};
 			local_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 			local_features.pNext = &fill_chain.front();
@@ -1305,18 +1305,18 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::add_desired_extensions(std::vect
 	return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_minimum_version(uint32_t major, uint32_t minor) {
-	criteria.required_version = VK_MAKE_VERSION(major, minor, 0);
+	criteria.required_version = VKB_MAKE_VK_VERSION(0, major, minor, 0);
 	return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_desired_version(uint32_t major, uint32_t minor) {
-	criteria.desired_version = VK_MAKE_VERSION(major, minor, 0);
+	criteria.desired_version = VKB_MAKE_VK_VERSION(0, major, minor, 0);
 	return *this;
 }
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features(VkPhysicalDeviceFeatures const& features) {
 	criteria.required_features = features;
 	return *this;
 }
-#if defined(VK_API_VERSION_1_2)
+#if defined(VKB_VK_API_VERSION_1_2)
 // Just calls add_required_features
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(
     VkPhysicalDeviceVulkan11Features features_11) {
@@ -1331,7 +1331,7 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(
 	return *this;
 }
 #endif
-#if defined(VK_API_VERSION_1_3)
+#if defined(VKB_VK_API_VERSION_1_3)
 PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_13(
     VkPhysicalDeviceVulkan13Features features_13) {
 	features_13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
@@ -1484,7 +1484,7 @@ detail::Result<Device> DeviceBuilder::build() const {
 	std::vector<VkBaseOutStructure*> final_pnext_chain;
 	VkDeviceCreateInfo device_create_info = {};
 
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 	for (auto& pnext : info.pNext_chain) {
 		if (pnext->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2) {
 			user_defined_phys_dev_features_2 = true;
@@ -1497,7 +1497,7 @@ detail::Result<Device> DeviceBuilder::build() const {
 	local_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
 	if (!user_defined_phys_dev_features_2) {
-		if (physical_device.instance_version >= VK_MAKE_VERSION(1, 1, 0)) {
+		if (physical_device.instance_version >= VKB_VK_API_VERSION_1_1) {
 			local_features2.features = physical_device.features;
 			final_pnext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&local_features2));
 			has_phys_dev_features_2 = true;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -27,6 +27,28 @@
 
 #include "VkBootstrapDispatch.h"
 
+#ifdef VK_MAKE_API_VERSION
+	#define VKB_MAKE_VK_VERSION(variant, major, minor, patch) VK_MAKE_API_VERSION(variant, major, minor, patch)
+#elif VK_API_VERSION
+	#define VKB_MAKE_VK_VERSION(variant, major, minor, patch) VK_API_VERSION(major, minor, patch)
+#endif
+
+#if defined(VK_API_VERSION_1_3) || defined(VK_VERSION_1_3)
+	#define VKB_VK_API_VERSION_1_3 VKB_MAKE_VK_VERSION(0, 1, 3, 0)
+#endif
+
+#if defined(VK_API_VERSION_1_2) || defined(VK_VERSION_1_2)
+	#define VKB_VK_API_VERSION_1_2 VKB_MAKE_VK_VERSION(0, 1, 2, 0)
+#endif
+
+#if defined(VK_API_VERSION_1_1) || defined(VK_VERSION_1_1)
+	#define VKB_VK_API_VERSION_1_1 VKB_MAKE_VK_VERSION(0, 1, 1, 0)
+#endif
+
+#if defined(VK_API_VERSION_1_0) || defined(VK_VERSION_1_0)
+	#define VKB_VK_API_VERSION_1_0 VKB_MAKE_VK_VERSION(0, 1, 0, 0)
+#endif
+
 namespace vkb {
 
 namespace detail {
@@ -259,7 +281,7 @@ struct Instance {
 	private:
 	bool headless = false;
 	bool supports_properties2_ext = false;
-	uint32_t instance_version = VK_MAKE_VERSION(1, 0, 0);
+	uint32_t instance_version = VKB_VK_API_VERSION_1_0;
 
 	friend class InstanceBuilder;
 	friend class PhysicalDeviceSelector;
@@ -378,8 +400,8 @@ class InstanceBuilder {
 		const char* engine_name = nullptr;
 		uint32_t application_version = 0;
 		uint32_t engine_version = 0;
-		uint32_t required_api_version = VK_MAKE_VERSION(1, 0, 0);
-		uint32_t desired_api_version = VK_MAKE_VERSION(1, 0, 0);
+		uint32_t required_api_version = VKB_VK_API_VERSION_1_0;
+		uint32_t desired_api_version = VKB_VK_API_VERSION_1_0;
 
 		// VkInstanceCreateInfo
 		std::vector<const char*> layers;
@@ -456,7 +478,7 @@ struct PhysicalDevice {
 	operator VkPhysicalDevice() const;
 
 	private:
-	uint32_t instance_version = VK_MAKE_VERSION(1, 0, 0);
+	uint32_t instance_version = VKB_VK_API_VERSION_1_0;
 	std::vector<const char*> extensions_to_enable;
 	std::vector<VkQueueFamilyProperties> queue_families;
 	std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
@@ -521,7 +543,7 @@ class PhysicalDeviceSelector {
 	PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);
 
 	// Require a physical device which supports a specific set of general/extension features.
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 	template <typename T>
 	PhysicalDeviceSelector& add_required_extension_features(T const& features) {
 		criteria.extended_features_chain.push_back(features);
@@ -530,7 +552,7 @@ class PhysicalDeviceSelector {
 #endif
 	// Require a physical device which supports the features in VkPhysicalDeviceFeatures.
 	PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features);
-#if defined(VK_API_VERSION_1_2)
+#if defined(VKB_VK_API_VERSION_1_2)
 	// Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
 	// Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
 	PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features features_11);
@@ -538,7 +560,7 @@ class PhysicalDeviceSelector {
 	// Must have vulkan version 1.2
 	PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features features_12);
 #endif
-#if defined(VK_API_VERSION_1_3)
+#if defined(VKB_VK_API_VERSION_1_3)
 	// Require a physical device which supports the features in VkPhysicalDeviceVulkan13Features.
 	// Must have vulkan version 1.3
 	PhysicalDeviceSelector& set_required_features_13(VkPhysicalDeviceVulkan13Features features_13);
@@ -556,7 +578,7 @@ class PhysicalDeviceSelector {
 	struct InstanceInfo {
 		VkInstance instance = VK_NULL_HANDLE;
 		VkSurfaceKHR surface = VK_NULL_HANDLE;
-		uint32_t version = VK_MAKE_VERSION(1, 0, 0);
+		uint32_t version = VKB_VK_API_VERSION_1_0;
 		bool headless = false;
 		bool supports_properties2_ext = false;
 	} instance_info;
@@ -570,7 +592,7 @@ class PhysicalDeviceSelector {
 		VkPhysicalDeviceMemoryProperties mem_properties{};
 
 // Because the KHR version is a typedef in Vulkan 1.1, it is safe to define one or the other.
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 device_features2{};
 #else
 		VkPhysicalDeviceFeatures2KHR device_features2{};
@@ -598,11 +620,11 @@ class PhysicalDeviceSelector {
 		std::vector<const char*> required_extensions;
 		std::vector<const char*> desired_extensions;
 
-		uint32_t required_version = VK_MAKE_VERSION(1, 0, 0);
-		uint32_t desired_version = VK_MAKE_VERSION(1, 0, 0);
+		uint32_t required_version = VKB_VK_API_VERSION_1_0;
+		uint32_t desired_version = VKB_VK_API_VERSION_1_0;
 
 		VkPhysicalDeviceFeatures required_features{};
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 		VkPhysicalDeviceFeatures2 required_features2{};
 		std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 #endif

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -531,7 +531,7 @@ TEST_CASE("Passing vkb classes to Vulkan handles", "[VkBootstrap.pass_class_to_h
 	}
 }
 
-#if defined(VK_API_VERSION_1_1)
+#if defined(VKB_VK_API_VERSION_1_1)
 TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]") {
 	GIVEN("A working instance") {
 		auto instance = get_headless_instance();
@@ -559,7 +559,7 @@ TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]"
 }
 #endif
 
-#if defined(VK_API_VERSION_1_2)
+#if defined(VKB_VK_API_VERSION_1_2)
 TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 	GIVEN("A working instance") {
 		vkb::InstanceBuilder builder;


### PR DESCRIPTION
The macros were used inconsistently used; sometimes `VK_API_VERSION_x_y`, sometimes `VK_VERSION_x_y`. I did not change the dispatch table, but they definitions could be re-used there too, as previously suggested in https://github.com/charles-lunarg/vk-bootstrap/issues/94#issuecomment-1031361373. And it should fix using older header versions where the `_API_` macros don't exist yet.