### PR TITLE
Add extensions in layers to main list

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -515,9 +515,11 @@ SystemInfo::SystemInfo() {
 		this->available_extensions.clear();
 	}
 
-	for (auto& ext : this->available_extensions)
-		if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0)
+	for (auto& ext : this->available_extensions) {
+		if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
 			debug_utils_available = true;
+		}
+	}
 
 	for (auto& layer : this->available_layers) {
 		std::vector<VkExtensionProperties> layer_extensions;
@@ -525,9 +527,13 @@ SystemInfo::SystemInfo() {
 		    detail::vulkan_functions().fp_vkEnumerateInstanceExtensionProperties,
 		    layer.layerName);
 		if (layer_extensions_ret == VK_SUCCESS) {
-			for (auto& ext : layer_extensions)
-				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0)
+			this->available_extensions.insert(
+			    this->available_extensions.end(), layer_extensions.begin(), layer_extensions.end());
+			for (auto& ext : layer_extensions) {
+				if (strcmp(ext.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
 					debug_utils_available = true;
+				}
+			}
 		}
 	}
 }
@@ -612,6 +618,8 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	app_info.apiVersion = api_version;
 
 	std::vector<const char*> extensions;
+	std::vector<const char*> layers;
+
 	for (auto& ext : info.extensions)
 		extensions.push_back(ext);
 	if (info.debug_callback != nullptr && system.debug_utils_available) {
@@ -653,7 +661,6 @@ detail::Result<Instance> InstanceBuilder::build() const {
 		return make_error_code(InstanceError::requested_extensions_not_present);
 	}
 
-	std::vector<const char*> layers;
 	for (auto& layer : info.layers)
 		layers.push_back(layer);
 

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -309,8 +309,8 @@ class InstanceBuilder {
 	// Require a vulkan instance API version. Will fail to create if this version isn't available.
 	InstanceBuilder& require_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
 
-	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the highest version available.
-	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the
+	// highest version available. Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
 	InstanceBuilder& desire_api_version(uint32_t preferred_vulkan_version);
 	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the highest version available.
 	InstanceBuilder& desire_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);


### PR DESCRIPTION
Allows apps to find all the extensions available. If they do not enable the layer the
extension comes from, the instance will fail creation due to missing the layer that
implements the extension.