### PR TITLE
Allow desiring higher api versions

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -602,13 +602,9 @@ detail::Result<Instance> InstanceBuilder::build() const {
 
 	uint32_t api_version = instance_version < VKB_VK_API_VERSION_1_1 ? instance_version : info.required_api_version;
 
-	if (info.desired_api_version > VKB_VK_API_VERSION_1_0) {
-		if (instance_version > info.desired_api_version) {
-			instance_version = info.desired_api_version;
-		}
-		if (api_version > info.desired_api_version) {
-			api_version = info.desired_api_version;
-		}
+	if (info.desired_api_version > VKB_VK_API_VERSION_1_0 && instance_version >= info.desired_api_version) {
+		instance_version = info.desired_api_version;
+		api_version = info.desired_api_version;
 	}
 
 	VkApplicationInfo app_info = {};

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -601,7 +601,10 @@ detail::Result<Instance> InstanceBuilder::build() const {
 		if (info.required_api_version > VKB_VK_API_VERSION_1_0) {
 			api_version = info.required_api_version;
 		}
-        if (info.desired_api_version > api_version && instance_version >= VKB_VK_API_VERSION_1_1){
+		if (instance_version > info.desired_api_version) {
+			instance_version = info.desired_api_version;
+		}
+		if (info.desired_api_version > api_version && instance_version >= VKB_VK_API_VERSION_1_1){
 			api_version = info.desired_api_version;
 		}
 	}
@@ -745,6 +748,8 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	instance.supports_properties2_ext = supports_properties2_ext;
 	instance.allocation_callbacks = info.allocation_callbacks;
 	instance.instance_version = instance_version;
+	instance.required_version = info.required_api_version;
+	instance.max_api_version = api_version;
 	instance.fp_vkGetInstanceProcAddr = detail::vulkan_functions().ptr_vkGetInstanceProcAddr;
 	instance.fp_vkGetDeviceProcAddr = detail::vulkan_functions().fp_vkGetDeviceProcAddr;
 	return instance;
@@ -1168,8 +1173,8 @@ PhysicalDeviceSelector::PhysicalDeviceSelector(Instance const& instance) {
 	instance_info.version = instance.instance_version;
 	instance_info.supports_properties2_ext = instance.supports_properties2_ext;
 	criteria.require_present = !instance.headless;
-	criteria.required_version = instance.instance_version;
-	criteria.desired_version = instance.instance_version;
+	criteria.required_version = instance.required_version;
+	criteria.desired_version = instance.max_api_version;
 }
 
 detail::Result<PhysicalDevice> PhysicalDeviceSelector::select() const {

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -282,6 +282,8 @@ struct Instance {
 	bool headless = false;
 	bool supports_properties2_ext = false;
 	uint32_t instance_version = VKB_VK_API_VERSION_1_0;
+	uint32_t required_version = VKB_VK_API_VERSION_1_0;
+	uint32_t max_api_version = VKB_VK_API_VERSION_1_0;
 
 	friend class InstanceBuilder;
 	friend class PhysicalDeviceSelector;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -282,8 +282,7 @@ struct Instance {
 	bool headless = false;
 	bool supports_properties2_ext = false;
 	uint32_t instance_version = VKB_VK_API_VERSION_1_0;
-	uint32_t required_version = VKB_VK_API_VERSION_1_0;
-	uint32_t max_api_version = VKB_VK_API_VERSION_1_0;
+	uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
 	friend class InstanceBuilder;
 	friend class PhysicalDeviceSelector;
@@ -340,16 +339,24 @@ class InstanceBuilder {
 	// Sets the (major, minor, patch) version of the engine.
 	InstanceBuilder& set_engine_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
 
-	// Require a vulkan instance API version. Will fail to create if this version isn't available.
+	// Require a vulkan API version. Will fail to create if this version isn't available.
 	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
 	InstanceBuilder& require_api_version(uint32_t required_api_version);
-	// Require a vulkan instance API version. Will fail to create if this version isn't available.
+	// Require a vulkan API version. Will fail to create if this version isn't available.
 	InstanceBuilder& require_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
+
+	// Overrides required API version for instance creation. Will fail to create if this version isn't available.
+	// Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	InstanceBuilder& set_minimum_instance_version(uint32_t minimum_instance_version);
+	// Overrides required API version for instance creation. Will fail to create if this version isn't available.
+	InstanceBuilder& set_minimum_instance_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
 
 	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the
 	// highest version available. Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+	[[deprecated("Use require_api_version + set_minimum_instance_version instead.")]]
 	InstanceBuilder& desire_api_version(uint32_t preferred_vulkan_version);
 	// Prefer a vulkan instance API version. If the desired version isn't available, it will use the highest version available.
+	[[deprecated("Use require_api_version + set_minimum_instance_version instead.")]]
 	InstanceBuilder& desire_api_version(uint32_t major, uint32_t minor, uint32_t patch = 0);
 
 	// Adds a layer to be enabled. Will fail to create an instance if the layer isn't available.
@@ -402,6 +409,7 @@ class InstanceBuilder {
 		const char* engine_name = nullptr;
 		uint32_t application_version = 0;
 		uint32_t engine_version = 0;
+		uint32_t minimum_instance_version = 0;
 		uint32_t required_api_version = VKB_VK_API_VERSION_1_0;
 		uint32_t desired_api_version = VKB_VK_API_VERSION_1_0;
 
@@ -540,6 +548,7 @@ class PhysicalDeviceSelector {
 	PhysicalDeviceSelector& add_desired_extensions(std::vector<const char*> extensions);
 
 	// Prefer a physical device that supports a (major, minor) version of vulkan.
+	[[deprecated("Use set_minimum_version + InstanceBuilder::require_api_version.")]]
 	PhysicalDeviceSelector& set_desired_version(uint32_t major, uint32_t minor);
 	// Require a physical device that supports a (major, minor) version of vulkan.
 	PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -30,7 +30,10 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
 		REQUIRE(sys_info_ret);
 
 		vkb::InstanceBuilder instance_builder;
-		auto instance_ret = instance_builder.use_default_debug_messenger().build();
+		auto instance_ret = instance_builder.require_api_version(1, 1, 0)
+		                        .set_minimum_instance_version(1, 0, 0)
+		                        .use_default_debug_messenger()
+		                        .build();
 		REQUIRE(instance_ret);
 		vkb::Instance instance = instance_ret.value();
 		auto surface = create_surface_glfw(instance.instance, window);
@@ -59,7 +62,6 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
 			                        .add_desired_extension(VK_KHR_MULTIVIEW_EXTENSION_NAME)
 			                        .add_required_extension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME)
 			                        .set_minimum_version(1, 0)
-			                        .set_desired_version(1, 1)
 			                        .select();
 			REQUIRE(phys_dev_ret.has_value());
 		}


### PR DESCRIPTION
Allows applications to desire_api_version that is
higher than available instance version.

It is possible to use PhysicalDevices with newer api version as long as your Instance is at least 1.1.
However application **must** not use newer api features if ApplicationInfo.apiVersion is set to lower value. ( [Vk spec Chap4. #VkApplicationInfo](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap4.html#VkApplicationInfo) )

This PR allows one to create instance with lower version while keeping ApplicationInfo::apiVersion at desired value