### PR TITLE
Added pNext chain support for swapchain::get_image_views

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1849,16 +1849,19 @@ detail::Result<std::vector<VkImage>> Swapchain::get_images() {
 	return swapchain_images;
 }
 detail::Result<std::vector<VkImageView>> Swapchain::get_image_views() {
-
-	auto swapchain_images_ret = get_images();
+	return get_image_views(nullptr);
+}
+detail::Result<std::vector<VkImageView>> Swapchain::get_image_views(const void* pNext) {
+	const auto swapchain_images_ret = get_images();
 	if (!swapchain_images_ret) return swapchain_images_ret.error();
-	auto swapchain_images = swapchain_images_ret.value();
+	const auto swapchain_images = swapchain_images_ret.value();
 
 	std::vector<VkImageView> views(swapchain_images.size());
 
 	for (size_t i = 0; i < swapchain_images.size(); i++) {
 		VkImageViewCreateInfo createInfo = {};
 		createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		createInfo.pNext = pNext;
 		createInfo.image = swapchain_images[i];
 		createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
 		createInfo.format = image_format;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -759,8 +759,10 @@ struct Swapchain {
 	detail::Result<std::vector<VkImage>> get_images();
 
 	// Returns a vector of VkImageView's to the VkImage's of the swapchain.
-	// VkImageViews must be destroyed.
+	// VkImageViews must be destroyed.  The pNext chain must be a nullptr or a valid
+	// structure.
 	detail::Result<std::vector<VkImageView>> get_image_views();
+	detail::Result<std::vector<VkImageView>> get_image_views(const void* pNext);
 	void destroy_image_views(std::vector<VkImageView> const& image_views);
 
 	// A conversion function which allows this Swapchain to be used

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -290,6 +290,23 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 				REQUIRE(image_views.value().size() > 0);
 				swapchain.destroy_image_views(image_views.value());
 			}
+			AND_THEN("Acquire swapchain images views with nullptr pNext chain") {
+				auto image_views = swapchain.get_image_views(nullptr);
+				REQUIRE(image_views.has_value());
+				REQUIRE(image_views.value().size() > 0);
+				swapchain.destroy_image_views(image_views.value());
+			}
+			AND_THEN("Acquire swapchain image views with valid pNext chain") {
+				VkImageViewUsageCreateInfo usage = {
+					VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO,
+					nullptr,
+					VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+				};
+				auto image_views = swapchain.get_image_views(&usage);
+				REQUIRE(image_views.has_value());
+				REQUIRE(image_views.value().size() > 0);
+				swapchain.destroy_image_views(image_views.value());
+			}
 
 			vkb::destroy_swapchain(swapchain_ret.value());
 		}


### PR DESCRIPTION
Adds an overload to `vkb::swapchain::get_image_views` to support passing a `pNext` chain.

Closes #122 