### PR TITLE
Fix best practices warning when in VK 1.1 or higher

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -610,7 +610,7 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	bool supports_properties2_ext =
 	    detail::check_extension_supported(system.available_extensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
-	if (supports_properties2_ext) {
+	if (supports_properties2_ext && api_version == VK_API_VERSION_1_0) {
 		extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -610,7 +610,7 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	bool supports_properties2_ext =
 	    detail::check_extension_supported(system.available_extensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
-	if (supports_properties2_ext && api_version == VK_API_VERSION_1_0) {
+	if (supports_properties2_ext && api_version < VKB_VK_API_VERSION_1_1) {
 		extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 


### PR DESCRIPTION
When using an API version other than VK 1.0 (read 1.1 and higher), we should use the functionality in core rather than the extension for getting the device physical properties.  This resolves the output produced by the best practices layer.