### PR TITLE
Fix c543dc1: portability_enumeration flag was not available before 1.3.208

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -710,9 +710,11 @@ detail::Result<Instance> InstanceBuilder::build() const {
 	instance_create_info.ppEnabledExtensionNames = extensions.data();
 	instance_create_info.enabledLayerCount = static_cast<uint32_t>(layers.size());
 	instance_create_info.ppEnabledLayerNames = layers.data();
+#if defined(VK_KHR_portability_enumeration)
 	if (portability_enumeration_support) {
 		instance_create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 	}
+#endif
 
 	Instance instance;
 	VkResult res =


### PR DESCRIPTION
c543dc1 introduced support for `VK_KHR_portability_enumeration`, but macro guard around the usage of `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` seems to have been forgotten, which made the program not compile for older header versions.