### PR TITLE
SwapchainBuilder: expose present_mode and requested_min_image_count in the resulting Swapchain

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1848,6 +1848,8 @@ detail::Result<Swapchain> SwapchainBuilder::build() const {
 	if (!images) {
 		return detail::Error{ SwapchainError::failed_get_swapchain_images };
 	}
+	swapchain.requested_min_image_count = image_count;
+	swapchain.present_mode = present_mode;
 	swapchain.image_count = static_cast<uint32_t>(images.value().size());
 	swapchain.allocation_callbacks = info.allocation_callbacks;
 	return swapchain;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -753,6 +753,8 @@ struct Swapchain {
 	uint32_t image_count = 0;
 	VkFormat image_format = VK_FORMAT_UNDEFINED;
 	VkExtent2D extent = { 0, 0 };
+	uint32_t requested_min_image_count = 0; // The value of minImageCount actually used when creating the swapchain; note that the presentation engine is always free to create more images than that.
+	VkPresentModeKHR present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR; // The present mode actually used when creating the swapchain.
 	VkAllocationCallbacks* allocation_callbacks = VK_NULL_HANDLE;
 
 	// Returns a vector of VkImage handles to the swapchain.


### PR DESCRIPTION
Hi,

It is as the title says; my use cases are : 

- I wanted a feature to get the present mode actually used for the swapchain, so I could display an indicator in my application;
- I wanted to easily get the value of `create_info.minImageCount`, to confirm (and display) whether or not we're likely in a double-buffering setup or triple-buffering setup. I know this does not prove anything, but I think it is interesting even as a hint.

Thanks for considering this, as always I am open to any feedback.