### PR TITLE
Use KHR structure for VK_KHR_pipeline_executable_properties

### DIFF
--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -2315,7 +2315,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_KHR_pipeline_executable_properties))
-	VkResult getPipelineExecutablePropertiesKHR(const VkPipelineInfoEXT* pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) const noexcept {
+	VkResult getPipelineExecutablePropertiesKHR(const VkPipelineInfoKHR* pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) const noexcept {
 		return fp_vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties);
 	}
 #endif


### PR DESCRIPTION
The spec defines two extensions, `VK_KHR_pipeline_executable_properties` and `VK_EXT_pipeline_properties`.

Both of these extensions define `VkPipelineInfo`, but one has the `KHR` suffix and one has the `EXT` suffix. The `EXT` suffixed structure is defined as an alias to the `KHR` structure.

Because the header here is checking for the presence of `VK_KHR_pipeline_executable_properties`, we should be using the `KHR` structure, as the `EXT` structure is not guaranteed to be defined. As of SDK 1.3.211.0, `VkPipelineInfoEXT` is not defined anywhere, causing a compilation error with this file.