### PR TITLE
Add exclusion list for alias in generator code

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -29,7 +29,7 @@
 # User will be prompted to install if not detected
 
 # Command Line Arguments
-# [--auto] Don't ask for input from the command line 
+# [--auto] Don't ask for input from the command line
 
 # Exclusions
 exclusions = [
@@ -41,6 +41,10 @@ exclusions = [
 # Excluded extension authors - don't generate anything for these types of extensions
 excluded_extension_authors = [
 	'NVX'
+]
+
+excluded_alias_types = [
+    'VkPipelineInfoKHR'
 ]
 
 # Check for/install xmltodict
@@ -288,7 +292,7 @@ for command in device_commands:
 				if i > 0:
 			 		args_names += ', '
 		else:
-			if arg_type in aliased_types:
+			if arg_type in aliased_types and  arg_type not in excluded_alias_types:
 				arg_type = aliased_types[arg_type]
 			args_full += arg_template.substitute(front_mods = front_mods, arg_type = arg_type, back_mods = back_mods, arg_name = arg_name, array = array)
 			args_names += arg_name

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -2318,7 +2318,7 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_KHR_pipeline_executable_properties))
-	VkResult getPipelineExecutablePropertiesKHR(const VkPipelineInfoEXT* pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) const noexcept {
+	VkResult getPipelineExecutablePropertiesKHR(const VkPipelineInfoKHR* pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) const noexcept {
 		return fp_vkGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties);
 	}
 #endif


### PR DESCRIPTION
Some alias types are not pure promotional types, and need to be excluded from the
code which replaces types with their alias.

This may be a stopgap solution for a larger underlying problem of not being able to
determine if an alias is promoted or not.

When I tested this change with the 1.3.211 SDK installed, it compiled successfully whereas before it printed the error messages with `VkPipelineInfoEXT`.

This is a competing solution to #146 