### PR TITLE
Fix crash during removal of unsuitable physical devices when using only_fully_suitable selection mode

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1235,7 +1235,7 @@ detail::Result<std::vector<PhysicalDevice>> PhysicalDeviceSelector::select_impl(
 	});
 
 	// Remove the partially suitable elements if they aren't desired
-	if (selection == DeviceSelectionMode::only_fully_suitable && partition_index != physical_devices.end()) {
+	if (selection == DeviceSelectionMode::only_fully_suitable) {
 		physical_devices.erase(partition_index, physical_devices.end());
 	}
 

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1235,8 +1235,8 @@ detail::Result<std::vector<PhysicalDevice>> PhysicalDeviceSelector::select_impl(
 	});
 
 	// Remove the partially suitable elements if they aren't desired
-	if (selection == DeviceSelectionMode::only_fully_suitable) {
-		physical_devices.erase(partition_index, physical_devices.end() - 1);
+	if (selection == DeviceSelectionMode::only_fully_suitable && partition_index != physical_devices.end()) {
+		physical_devices.erase(partition_index, physical_devices.end());
 	}
 
 	// Make the physical device ready to be used to create a Device from it


### PR DESCRIPTION
The second argument to erase is exclusive, so we want to use `.end()` directly; otherwise we'll either fail to remove the very last element (if the range is non-empty) or crash (if `partition_index` is `physical_devices.end()`).