### PR TITLE
Expose the final color space used when creating swapchains

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1852,6 +1852,7 @@ detail::Result<Swapchain> SwapchainBuilder::build() const {
 	}
 	swapchain.device = info.device;
 	swapchain.image_format = surface_format.format;
+	swapchain.color_space = surface_format.colorSpace;
 	swapchain.extent = extent;
 	detail::vulkan_functions().get_device_proc_addr(
 	    info.device, swapchain.internal_table.fp_vkGetSwapchainImagesKHR, "vkGetSwapchainImagesKHR");

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -752,7 +752,7 @@ struct Swapchain {
 	VkDevice device = VK_NULL_HANDLE;
 	VkSwapchainKHR swapchain = VK_NULL_HANDLE;
 	uint32_t image_count = 0;
-	VkFormat image_format = VK_FORMAT_UNDEFINED; // THe image format actually used when creating the swapchain.
+	VkFormat image_format = VK_FORMAT_UNDEFINED; // The image format actually used when creating the swapchain.
 	VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR; // The color space actually used when creating the swapchain.
 	VkExtent2D extent = { 0, 0 };
 	uint32_t requested_min_image_count = 0; // The value of minImageCount actually used when creating the swapchain; note that the presentation engine is always free to create more images than that.

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -752,7 +752,8 @@ struct Swapchain {
 	VkDevice device = VK_NULL_HANDLE;
 	VkSwapchainKHR swapchain = VK_NULL_HANDLE;
 	uint32_t image_count = 0;
-	VkFormat image_format = VK_FORMAT_UNDEFINED;
+	VkFormat image_format = VK_FORMAT_UNDEFINED; // THe image format actually used when creating the swapchain.
+	VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR; // The color space actually used when creating the swapchain.
 	VkExtent2D extent = { 0, 0 };
 	uint32_t requested_min_image_count = 0; // The value of minImageCount actually used when creating the swapchain; note that the presentation engine is always free to create more images than that.
 	VkPresentModeKHR present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR; // The present mode actually used when creating the swapchain.


### PR DESCRIPTION
This just passes through the final color space used after finding a suitable surface format to the user so it can be queried later.