### PR TITLE
Properly handle forward-declared structs

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -195,7 +195,7 @@ for command in device_commands:
 				if collection_count > 0:
 					collection_count -= 1
 					if collection_count > 0:
-				 		macro += ' || '
+						macro += ' || '
 		macro += '\n$body#endif\n'
 	else:
 		macro = '$body'
@@ -276,6 +276,9 @@ for command in device_commands:
 			elif text == '**':
 				front_mods = ''
 				back_mods = '** '
+			elif text == 'struct**':
+				front_mods = 'struct '
+				back_mods = '** '
 			elif text == 'const*':
 				front_mods = 'const '
 				back_mods = '* '
@@ -285,12 +288,15 @@ for command in device_commands:
 			elif text == 'const*const*':
 				front_mods = 'const '
 				back_mods = '* const* '
+			elif text == 'conststruct*':
+				front_mods = 'const struct '
+				back_mods = '* '
 		if i == args_count and arg_type == 'VkDevice':
 			args_names += arg_name
 			if i > 0:
 				i -= 1
 				if i > 0:
-			 		args_names += ', '
+					args_names += ', '
 		else:
 			if arg_type in aliased_types and  arg_type not in excluded_alias_types:
 				arg_type = aliased_types[arg_type]
@@ -299,8 +305,8 @@ for command in device_commands:
 			if i > 0:
 				i -= 1
 				if i > 0:
-			 		args_full += ', '
-			 		args_names += ', '
+					args_full += ', '
+					args_names += ', '
 
 	proxy_body = proxy_template.substitute(return_type = return_type, proxy_name = proxy_name, args_full = args_full, opt_return = opt_return, fp_name = fp_name, args_names = args_names)
 	fp_decl_body = fp_decl_template.substitute(pfn_name = pfn_name, fp_name = fp_name)

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -1995,12 +1995,12 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
-	VkResult getAndroidHardwareBufferPropertiesANDROID(AHardwareBuffer buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) const noexcept {
+	VkResult getAndroidHardwareBufferPropertiesANDROID(const struct AHardwareBuffer* buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) const noexcept {
 		return fp_vkGetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties);
 	}
 #endif
 #if (defined(VK_ANDROID_external_memory_android_hardware_buffer))
-	VkResult getMemoryAndroidHardwareBufferANDROID(const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, AHardwareBuffer pBuffer) const noexcept {
+	VkResult getMemoryAndroidHardwareBufferANDROID(const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, struct AHardwareBuffer** pBuffer) const noexcept {
 		return fp_vkGetMemoryAndroidHardwareBufferANDROID(device, pInfo, pBuffer);
 	}
 #endif
@@ -2625,13 +2625,13 @@ struct DispatchTable {
 	}
 #endif
 #if (defined(VK_KHR_video_queue))
-	VkResult getVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR videoSession, uint32_t* pVideoSessionMemoryRequirementsCount, VkVideoGetMemoryPropertiesKHR* pVideoSessionMemoryRequirements) const noexcept {
-		return fp_vkGetVideoSessionMemoryRequirementsKHR(device, videoSession, pVideoSessionMemoryRequirementsCount, pVideoSessionMemoryRequirements);
+	VkResult getVideoSessionMemoryRequirementsKHR(VkVideoSessionKHR videoSession, uint32_t* pMemoryRequirementsCount, VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements) const noexcept {
+		return fp_vkGetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount, pMemoryRequirements);
 	}
 #endif
 #if (defined(VK_KHR_video_queue))
-	VkResult bindVideoSessionMemoryKHR(VkVideoSessionKHR videoSession, uint32_t videoSessionBindMemoryCount, const VkVideoBindMemoryKHR* pVideoSessionBindMemories) const noexcept {
-		return fp_vkBindVideoSessionMemoryKHR(device, videoSession, videoSessionBindMemoryCount, pVideoSessionBindMemories);
+	VkResult bindVideoSessionMemoryKHR(VkVideoSessionKHR videoSession, uint32_t bindSessionMemoryInfoCount, const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos) const noexcept {
+		return fp_vkBindVideoSessionMemoryKHR(device, videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos);
 	}
 #endif
 #if (defined(VK_KHR_video_decode_queue))


### PR DESCRIPTION
- Remove a couple random spaces in the Python file
- Add cases to the argument parsing logic to handle forwrad-declared struct, e.g. types with `struct` in the modifiers

Resolves #162 