### PR TITLE
Stricter verifications in SwapchainBuilder and other default format feature

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1633,9 +1633,8 @@ Result<SurfaceSupportDetails> query_surface_support_details(VkPhysicalDevice phy
 	return SurfaceSupportDetails{ capabilities, formats, present_modes };
 }
 
-Result<VkSurfaceFormatKHR> find_desired_surface_format(VkPhysicalDevice /* phys_device */,
-    std::vector<VkSurfaceFormatKHR> const& available_formats,
-    std::vector<VkSurfaceFormatKHR> const& desired_formats) {
+Result<VkSurfaceFormatKHR> find_desired_surface_format(
+    std::vector<VkSurfaceFormatKHR> const& available_formats, std::vector<VkSurfaceFormatKHR> const& desired_formats) {
 	for (auto const& desired_format : desired_formats) {
 		for (auto const& available_format : available_formats) {
 			// finds the first format that is desired and available
@@ -1649,10 +1648,9 @@ Result<VkSurfaceFormatKHR> find_desired_surface_format(VkPhysicalDevice /* phys_
 	return { make_error_code(SurfaceSupportError::no_suitable_desired_format) };
 }
 
-VkSurfaceFormatKHR find_best_surface_format(VkPhysicalDevice phys_device,
-    std::vector<VkSurfaceFormatKHR> const& available_formats,
-    std::vector<VkSurfaceFormatKHR> const& desired_formats) {
-	auto surface_format_ret = detail::find_desired_surface_format(phys_device, available_formats, desired_formats);
+VkSurfaceFormatKHR find_best_surface_format(
+    std::vector<VkSurfaceFormatKHR> const& available_formats, std::vector<VkSurfaceFormatKHR> const& desired_formats) {
+	auto surface_format_ret = detail::find_desired_surface_format(available_formats, desired_formats);
 	if (surface_format_ret.has_value()) return surface_format_ret.value();
 
 	// use the first available format as a fallback if any desired formats aren't found
@@ -1775,7 +1773,7 @@ Result<Swapchain> SwapchainBuilder::build() const {
 	}
 
 	VkSurfaceFormatKHR surface_format =
-	    detail::find_best_surface_format(info.physical_device, surface_support.formats, desired_formats);
+	    detail::find_best_surface_format(surface_support.formats, desired_formats);
 
 	VkExtent2D extent = detail::find_extent(surface_support.capabilities, info.desired_width, info.desired_height);
 

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -842,23 +842,13 @@ class SwapchainBuilder {
 	SwapchainBuilder& use_default_present_mode_selection();
 
 	// Set the bitmask of the image usage for acquired swapchain images.
-	// If the surface capabilities cannot allow it, building the swapchain will result in the `SwapchainError::required_usage_or_features_not_supported` error.
+	// If the surface capabilities cannot allow it, building the swapchain will result in the `SwapchainError::required_usage_not_supported` error.
 	SwapchainBuilder& set_image_usage_flags(VkImageUsageFlags usage_flags);
 	// Add a image usage to the bitmask for acquired swapchain images.
 	SwapchainBuilder& add_image_usage_flags(VkImageUsageFlags usage_flags);
 	// Use the default image usage bitmask values. This is the default if no image usages
 	// are provided. The default is VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
 	SwapchainBuilder& use_default_image_usage_flags();
-
-	// Set the bitmask of the format feature flag for acquired swapchain images.
-	// Use this functionnality only if you require formats to support a set of feature flags 
-	// that are not already implied by set_image_usage_flags
-	SwapchainBuilder& set_format_feature_flags(VkFormatFeatureFlags feature_flags);
-	// Add a format feature to the bitmask for acquired swapchain images.
-	SwapchainBuilder& add_format_feature_flags(VkFormatFeatureFlags feature_flags);
-	// Use the default format feature bitmask values. This is the default if no format features
-	// are provided. The default is 0
-	SwapchainBuilder& use_default_format_feature_flags();
 
 	// Set the number of views in for multiview/stereo surface
 	SwapchainBuilder& set_image_array_layer_count(uint32_t array_layer_count);
@@ -926,7 +916,6 @@ class SwapchainBuilder {
 		uint32_t min_image_count = 0;
 		uint32_t required_min_image_count = 0;
 		VkImageUsageFlags image_usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-		VkFormatFeatureFlags format_feature_flags = 0;
 		uint32_t graphics_queue_index = 0;
 		uint32_t present_queue_index = 0;
 		VkSurfaceTransformFlagBitsKHR pre_transform = static_cast<VkSurfaceTransformFlagBitsKHR>(0);

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -213,7 +213,7 @@ enum class SwapchainError {
 	failed_get_swapchain_images,
 	failed_create_swapchain_image_views,
 	required_min_image_count_too_low,
-	required_usage_or_features_not_supported
+	required_usage_not_supported
 };
 
 std::error_code make_error_code(InstanceError instance_error);
@@ -851,9 +851,8 @@ class SwapchainBuilder {
 	SwapchainBuilder& use_default_image_usage_flags();
 
 	// Set the bitmask of the format feature flag for acquired swapchain images.
-	// If the desired formats cannot allow it, building the swapchain will result in the
-	// `SwapchainError::required_usage_or_features_not_supported` error. Use this functionnality only if you require
-	// formats to support a set of feature flags that are not already implied by set_image_usage_flags
+	// Use this functionnality only if you require formats to support a set of feature flags 
+	// that are not already implied by set_image_usage_flags
 	SwapchainBuilder& set_format_feature_flags(VkFormatFeatureFlags feature_flags);
 	// Add a format feature to the bitmask for acquired swapchain images.
 	SwapchainBuilder& add_format_feature_flags(VkFormatFeatureFlags feature_flags);

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -213,6 +213,7 @@ enum class SwapchainError {
 	failed_get_swapchain_images,
 	failed_create_swapchain_image_views,
 	required_min_image_count_too_low,
+	required_usage_or_features_not_supported
 };
 
 std::error_code make_error_code(InstanceError instance_error);
@@ -841,6 +842,7 @@ class SwapchainBuilder {
 	SwapchainBuilder& use_default_present_mode_selection();
 
 	// Set the bitmask of the image usage for acquired swapchain images.
+	// If the surface capabilities cannot allow it, building the swapchain will result in the `SwapchainError::required_usage_or_features_not_supported` error.
 	SwapchainBuilder& set_image_usage_flags(VkImageUsageFlags usage_flags);
 	// Add a image usage to the bitmask for acquired swapchain images.
 	SwapchainBuilder& add_image_usage_flags(VkImageUsageFlags usage_flags);
@@ -849,11 +851,14 @@ class SwapchainBuilder {
 	SwapchainBuilder& use_default_image_usage_flags();
 
 	// Set the bitmask of the format feature flag for acquired swapchain images.
+	// If the desired formats cannot allow it, building the swapchain will result in the
+	// `SwapchainError::required_usage_or_features_not_supported` error. Use this functionnality only if you require
+	// formats to support a set of feature flags that are not already implied by set_image_usage_flags
 	SwapchainBuilder& set_format_feature_flags(VkFormatFeatureFlags feature_flags);
 	// Add a format feature to the bitmask for acquired swapchain images.
 	SwapchainBuilder& add_format_feature_flags(VkFormatFeatureFlags feature_flags);
 	// Use the default format feature bitmask values. This is the default if no format features
-	// are provided. The default is VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT
+	// are provided. The default is 0
 	SwapchainBuilder& use_default_format_feature_flags();
 
 	// Set the number of views in for multiview/stereo surface
@@ -922,7 +927,7 @@ class SwapchainBuilder {
 		uint32_t min_image_count = 0;
 		uint32_t required_min_image_count = 0;
 		VkImageUsageFlags image_usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-		VkFormatFeatureFlags format_feature_flags = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
+		VkFormatFeatureFlags format_feature_flags = 0;
 		uint32_t graphics_queue_index = 0;
 		uint32_t present_queue_index = 0;
 		VkSurfaceTransformFlagBitsKHR pre_transform = static_cast<VkSurfaceTransformFlagBitsKHR>(0);

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -305,7 +305,6 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 			vkb::SwapchainBuilder swapchain_builder(device);
 			auto swapchain_ret = swapchain_builder.set_desired_extent(256, 256)
 			                         .set_desired_format({ VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
-			                         .add_fallback_format({ VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
 			                         .set_desired_present_mode(VK_PRESENT_MODE_IMMEDIATE_KHR)
 			                         .set_pre_transform_flags(VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
 			                         .set_composite_alpha_flags(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -305,6 +305,7 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 			vkb::SwapchainBuilder swapchain_builder(device);
 			auto swapchain_ret = swapchain_builder.set_desired_extent(256, 256)
 			                         .set_desired_format({ VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
+			                         .add_fallback_format({ VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
 			                         .set_desired_present_mode(VK_PRESENT_MODE_IMMEDIATE_KHR)
 			                         .set_pre_transform_flags(VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
 			                         .set_composite_alpha_flags(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)


### PR DESCRIPTION
To solve #169, I chose the following approach:

1. Remove default format_feature_flag (set to 0)
2. Enforce checking of user requirements (format features, image usage and desired formats)
3. To check image usage, only basic verification is done, by checking that the usage match the swapchain capabilities (in the usual case of non-shared present modes)

See below some notes on the change to explain the decision:

1. Even _VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT_ is not a good default because it implies that the format should support usage _VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT_, which is not mandatory by the spec (color attachment is the only mandatory usage for implementers).
2. This broke a test on my machine because it doesn't support _VK_FORMAT_R8G8B8A8_UNORM_ as swapchain format. It should have never passed though - maybe validation caught the issue, but I couldn't see it.
--> This may be a breaking change
3. I am not sure this is enough validation, but it should be a good start.

Don't hesitate changing the code, or commenting on this. I am motivated to improve this if needed !