### PR TITLE
Allow vkb::Device::get_queue to return a graphics queue as a fallback when no separate compute / transfer queue found.

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -933,19 +933,11 @@ bool supports_features(VkPhysicalDeviceFeatures supported,
 	return true;
 }
 // clang-format on
-// Finds the first queue which supports the desired operations. Returns QUEUE_INDEX_MAX_VALUE if none is found
-uint32_t get_first_queue_index(std::vector<VkQueueFamilyProperties> const& families, VkQueueFlags desired_flags) {
-	for (uint32_t i = 0; i < static_cast<uint32_t>(families.size()); i++) {
-		if ((families[i].queueFlags & desired_flags) == desired_flags) return i;
-	}
-	return QUEUE_INDEX_MAX_VALUE;
-}
 
-// Finds the queue which is separate from the graphics queue and has the desired flag and not the
-// undesired flag, but will select it if no better options are available compute support. Returns
-// QUEUE_INDEX_MAX_VALUE if none is found.
+// Finds the first queue which has the desired flag and not the undesired flag (defaults to none),
+// but will select it if no better options are available. Returns QUEUE_INDEX_MAX_VALUE if none is found.
 uint32_t get_first_queue_index(
-    std::vector<VkQueueFamilyProperties> const& families, VkQueueFlags desired_flags, VkQueueFlags undesired_flags) {
+    std::vector<VkQueueFamilyProperties> const& families, VkQueueFlags desired_flags, VkQueueFlags undesired_flags = 0) {
 	uint32_t index = QUEUE_INDEX_MAX_VALUE;
 	for (uint32_t i = 0; i < static_cast<uint32_t>(families.size()); i++) {
 		if ((families[i].queueFlags & desired_flags) == desired_flags) {


### PR DESCRIPTION
As mentioned in #109 , vkb currently throws an error when trying to get a compute / transfer queue in low-end devices that has no separate queues.

Following changes are made to allow `vkb::Device::get_queue(_index)` to return a graphics queue as a fallback:

1. add a `undesired_flags` parameter to `vkb::detail::get_first_queue_index`, it defaults to 0 to avoid changing existing calls
2. use a modified implementation of `get_seperate_queue_index` which removes the graphics queue limitation to rewrite the function
3. replace `get_seperate_queue_index` in `vkb::Device::get_queue_index` with `get_first_queue_index` and specify graphics & compute/transfer queue as undesired flags

Hope this can help.