### PR TITLE
Implement unwrap and expect error handling functions for Result.

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -146,6 +146,22 @@ template <typename T> class Result {
 	bool has_value() const { return m_init; }
 	explicit operator bool() const { return m_init; }
 
+	// return the value if exists, otherwise throw a runtime error with the default message
+	T unwrap() {
+		if(m_init) {
+			return m_value;
+		}
+		throw std::runtime_error(m_error.type.message());
+	}
+
+	// return the value if exists, otherwise throw a runtime error with the provided message
+	T expect(const std::string& message) {
+		if(m_init) {
+			return m_value;
+		}
+		throw std::runtime_error(message);
+	}
+
 	private:
 	void destroy() {
 		if (m_init) m_value.~T();

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -36,6 +36,7 @@
 
 #if defined(VK_API_VERSION_1_3) || defined(VK_VERSION_1_3)
 #define VKB_VK_API_VERSION_1_3 VKB_MAKE_VK_VERSION(0, 1, 3, 0)
+#define VKB_VK_API_VERSION_LATEST VKB_VK_API_VERSION_1_3
 #endif
 
 #if defined(VK_API_VERSION_1_2) || defined(VK_VERSION_1_2)


### PR DESCRIPTION
```cpp
try {
        // Crash the program with the default error message if an error occured
        auto instance = instance_builder.use_default_debug_messenger().request_validation_layers().build().unwrap();
        // Crash the program with a custom error message if an error occured
        auto physical_device = vkb::PhysicalDeviceSelector(instance).select().expect("Couldn't select a suitable physical device");
        return EXIT_SUCCESS;
} catch (std::exception &e) {
        std::cerr << e.what() << std::endl;
        return EXIT_FAILURE;
}
```