### PR TITLE
Add new error condition for DeviceBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `vk-bootstrap`
 
-A utility library that jump starts initialization of Vulkan 
+A utility library that jump starts initialization of Vulkan
 
 This library simplifies the tedious process of:
 
@@ -76,19 +76,19 @@ See `example/triangle.cpp` for an example that renders a triangle to the screen.
 
 ## Setting up `vk-bootstrap`
 
-This library has no external dependencies beyond C++14, its standard library, and the Vulkan Headers.
+This library has no external dependencies beyond C++14, its standard library, and at least the 1.1 version of the Vulkan Headers.
 
-Note: on Unix platforms, `vk-bootstrap` will require the dynamic linker in order to compile as the library doesn't link against `vulkan-1.dll`/`libvulkan.so` directly. 
+Note: on Unix platforms, `vk-bootstrap` will require the dynamic linker in order to compile as the library doesn't link against `vulkan-1.dll`/`libvulkan.so` directly.
 
 ### Copy-Paste
 
-Copy the `src/VkBootstrap.h` and `src/VkBootstrap.cpp` files into your project, include them into your build, then compile as you normally would.
+Copy the `src/VkBootstrap.h`, `src/VkBootstrapDispatch.h`, and `src/VkBootstrap.cpp` files into your project, include them into your build, then compile as you normally would.
 
 `vk-bootstrap` is *not* a header only library, so no need to worry about macros in the header.
 
 #### Linux specific
 
-vk-bootstrap will load the required symbols at runtime, which requires that the application is linked to the system dynamic link. 
+vk-bootstrap will load the required symbols at runtime, which requires that the application is linked to the system dynamic link.
 How the dynamic linker is linked into the project depends on the build system in question.
 If CMake is being used, link vk-bootstrap with `${CMAKE_DL_LIBS}`.
 
@@ -106,7 +106,7 @@ With CMake, add the subdirectory to include the project
 add_subdirectory(vk-bootstrap)
 ```
 
-Then use `target_link_libraries` to use the library in whichever target needs it. 
+Then use `target_link_libraries` to use the library in whichever target needs it.
 
 ```cmake
 target_link_libraries(your_application_name vk-bootstrap::vk-bootstrap)
@@ -120,7 +120,7 @@ include(FetchContent)
 FetchContent_Declare(
     fetch_vk_bootstrap
     GIT_REPOSITORY https://github.com/charles-lunarg/vk-bootstrap
-    GIT_TAG        BRANCH_OR_TAG #suggest using a tag so the library doesn't update whenever new commits are pushed to a branch 
+    GIT_TAG        BRANCH_OR_TAG #suggest using a tag so the library doesn't update whenever new commits are pushed to a branch
 )
 FetchContent_MakeAvailable(fetch_vk_bootstrap)
 target_link_libraries(your_application_name vk-bootstrap::vk-bootstrap)
@@ -151,7 +151,7 @@ cmake ../path/to/your_project/ -DVK_BOOTSTRAP_TEST=ON
 
 ### Build Options
 | Name | Type |  Default Value | Description |
-| ---- | --- | ---- | ----- | 
+| ---- | --- | ---- | ----- |
 | `VK_BOOTSTRAP_WERROR` | bool | `OFF` | Enable warnings as errors during compilation. |
 | `VK_BOOTSTRAP_TEST` | bool | `OFF` | Enable building of the tests in this project. Will download GLFW and Catch2 automatically if enabled. |
 | `VK_BOOTSTRAP_VULKAN_HEADER_DIR` | string | `""` | Optional. Specify the directory that contains the Vulkan Headers. Useful if you are downloading the headers manually and don't want vk-bootstrap to download them itself. |

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1519,8 +1519,7 @@ Result<Device> DeviceBuilder::build() const {
 			}
 		}
 	} else {
-		printf("User provided VkPhysicalDeviceFeatures2 instance found in pNext chain. All "
-		       "requirements added via 'add_required_extension_features' will be ignored.");
+		return { DeviceError::VkPhysicalDeviceFeatures2_in_pNext_chain_while_using_add_required_extension_features };
 	}
 
 	if (!user_defined_phys_dev_features_2 && !has_phys_dev_features_2) {
@@ -1772,8 +1771,7 @@ Result<Swapchain> SwapchainBuilder::build() const {
 		image_count = surface_support.capabilities.maxImageCount;
 	}
 
-	VkSurfaceFormatKHR surface_format =
-	    detail::find_best_surface_format(surface_support.formats, desired_formats);
+	VkSurfaceFormatKHR surface_format = detail::find_best_surface_format(surface_support.formats, desired_formats);
 
 	VkExtent2D extent = detail::find_extent(surface_support.capabilities, info.desired_width, info.desired_height);
 

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -205,6 +205,7 @@ enum class QueueError {
 };
 enum class DeviceError {
 	failed_create_device,
+	VkPhysicalDeviceFeatures2_in_pNext_chain_while_using_add_required_extension_features,
 };
 enum class SwapchainError {
 	surface_handle_not_provided,
@@ -594,6 +595,8 @@ class PhysicalDeviceSelector {
 	PhysicalDeviceSelector& disable_portability_subset();
 
 	// Require a physical device which supports a specific set of general/extension features.
+	// If this function is used, the user should not put their own VkPhysicalDeviceFeatures2 in
+	// the pNext chain of VkDeviceCreateInfo.
 #if defined(VKB_VK_API_VERSION_1_1)
 	template <typename T> PhysicalDeviceSelector& add_required_extension_features(T const& features) {
 		criteria.extended_features_chain.push_back(features);

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -501,11 +501,8 @@ struct PhysicalDevice {
 	std::vector<std::string> extensions;
 	std::vector<VkQueueFamilyProperties> queue_families;
 	std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
-#if defined(VKB_VK_API_VERSION_1_1)
 	VkPhysicalDeviceFeatures2 features2{};
-#else
-	VkPhysicalDeviceFeatures2KHR features2{};
-#endif
+
 	bool defer_surface_initialization = false;
 	bool properties2_ext_enabled = false;
 	enum class Suitable { yes, partial, no };
@@ -598,12 +595,11 @@ class PhysicalDeviceSelector {
 	// Require a physical device which supports a specific set of general/extension features.
 	// If this function is used, the user should not put their own VkPhysicalDeviceFeatures2 in
 	// the pNext chain of VkDeviceCreateInfo.
-#if defined(VKB_VK_API_VERSION_1_1)
 	template <typename T> PhysicalDeviceSelector& add_required_extension_features(T const& features) {
 		criteria.extended_features_chain.push_back(features);
 		return *this;
 	}
-#endif
+
 	// Require a physical device which supports the features in VkPhysicalDeviceFeatures.
 	PhysicalDeviceSelector& set_required_features(VkPhysicalDeviceFeatures const& features);
 #if defined(VKB_VK_API_VERSION_1_2)
@@ -659,9 +655,8 @@ class PhysicalDeviceSelector {
 		uint32_t desired_version = VKB_VK_API_VERSION_1_0;
 
 		VkPhysicalDeviceFeatures required_features{};
-#if defined(VK_KHR_get_physical_device_properties2)
-		VkPhysicalDeviceFeatures2KHR required_features2{};
-#endif
+		VkPhysicalDeviceFeatures2 required_features2{};
+
 		std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 		bool defer_surface_initialization = false;
 		bool use_first_gpu_unconditionally = false;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -288,7 +288,7 @@ struct Instance {
 
 	private:
 	bool headless = false;
-	bool supports_properties2_ext = false;
+	bool properties2_ext_enabled = false;
 	uint32_t instance_version = VKB_VK_API_VERSION_1_0;
 	uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
@@ -507,6 +507,7 @@ struct PhysicalDevice {
 	VkPhysicalDeviceFeatures2KHR features2{};
 #endif
 	bool defer_surface_initialization = false;
+	bool properties2_ext_enabled = false;
 	enum class Suitable { yes, partial, no };
 	Suitable suitable = Suitable::yes;
 	friend class PhysicalDeviceSelector;
@@ -633,7 +634,7 @@ class PhysicalDeviceSelector {
 		VkSurfaceKHR surface = VK_NULL_HANDLE;
 		uint32_t version = VKB_VK_API_VERSION_1_0;
 		bool headless = false;
-		bool supports_properties2_ext = false;
+		bool properties2_ext_enabled = false;
 	} instance_info;
 
 	// We copy the extension features stored in the selector criteria under the prose of a
@@ -658,10 +659,10 @@ class PhysicalDeviceSelector {
 		uint32_t desired_version = VKB_VK_API_VERSION_1_0;
 
 		VkPhysicalDeviceFeatures required_features{};
-#if defined(VKB_VK_API_VERSION_1_1)
-		VkPhysicalDeviceFeatures2 required_features2{};
-		std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
+#if defined(VK_KHR_get_physical_device_properties2)
+		VkPhysicalDeviceFeatures2KHR required_features2{};
 #endif
+		std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
 		bool defer_surface_initialization = false;
 		bool use_first_gpu_unconditionally = false;
 		bool enable_portability_subset = true;

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -335,6 +335,7 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 			auto recreated_swapchain_ret = swapchain_builder.set_old_swapchain(swapchain).build();
 			REQUIRE(recreated_swapchain_ret.has_value());
 
+			vkb::destroy_swapchain(swapchain_ret.value());
 			vkb::destroy_swapchain(recreated_swapchain_ret.value());
 		}
 		AND_THEN("Swapchain can be created from individual handles") {
@@ -348,6 +349,7 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 			auto recreated_swapchain_ret = swapchain_builder.set_old_swapchain(swapchain).build();
 			REQUIRE(recreated_swapchain_ret.has_value());
 
+			vkb::destroy_swapchain(swapchain_ret.value());
 			vkb::destroy_swapchain(recreated_swapchain_ret.value());
 		}
 		AND_THEN("Swapchain can be create with default gotten handles") {
@@ -360,6 +362,7 @@ TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
 			auto recreated_swapchain_ret = swapchain_builder.set_old_swapchain(swapchain).build();
 			REQUIRE(recreated_swapchain_ret.has_value());
 
+			vkb::destroy_swapchain(swapchain_ret.value());
 			vkb::destroy_swapchain(recreated_swapchain_ret.value());
 		}
 

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -566,8 +566,7 @@ TEST_CASE("Passing vkb classes to Vulkan handles", "[VkBootstrap.pass_class_to_h
 TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]") {
 	GIVEN("A working instance") {
 		auto instance = get_headless_instance();
-		// Requires a device that supports runtime descriptor arrays via descriptor indexing extension.
-		{
+		SECTION("Requires a device that supports runtime descriptor arrays via descriptor indexing extension.") {
 			VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features{};
 			descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
 			descriptor_indexing_features.runtimeDescriptorArray = true;
@@ -585,6 +584,52 @@ TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]"
 			REQUIRE(device_ret.has_value());
 			vkb::destroy_device(device_ret.value());
 		}
+		SECTION("Add a custom VkPhysicalDeviceFeatures2 pNext chain to the DeviceBuilder, without using "
+		        "add_required_extension_features()") {
+			VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features{};
+			descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+			descriptor_indexing_features.runtimeDescriptorArray = true;
+
+			vkb::PhysicalDeviceSelector selector(instance);
+			auto phys_dev_ret = selector.add_required_extension(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)
+			                        .add_required_extension(VK_KHR_MAINTENANCE3_EXTENSION_NAME)
+			                        .select();
+			// Ignore if hardware support isn't true
+			REQUIRE(phys_dev_ret.has_value());
+
+			VkPhysicalDeviceFeatures2 phys_dev_feats2{};
+			phys_dev_feats2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+			phys_dev_feats2.pNext = reinterpret_cast<void*>(&descriptor_indexing_features);
+
+			vkb::DeviceBuilder device_builder(phys_dev_ret.value());
+			auto device_ret = device_builder.add_pNext(&phys_dev_feats2).build();
+			REQUIRE(device_ret.has_value());
+			vkb::destroy_device(device_ret.value());
+		}
+		SECTION(
+		    "Try to add a custom VkPhysicalDeviceFeatures2 pNext chain to the DeviceBuilder, resulting in an error") {
+			VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features{};
+			descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+			descriptor_indexing_features.runtimeDescriptorArray = true;
+
+			vkb::PhysicalDeviceSelector selector(instance);
+			auto phys_dev_ret = selector.add_required_extension(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)
+			                        .add_required_extension(VK_KHR_MAINTENANCE3_EXTENSION_NAME)
+			                        .add_required_extension_features(descriptor_indexing_features)
+			                        .select();
+			// Ignore if hardware support isn't true
+			REQUIRE(phys_dev_ret.has_value());
+
+			VkPhysicalDeviceFeatures2 phys_dev_feats2{};
+			phys_dev_feats2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+			phys_dev_feats2.pNext = reinterpret_cast<void*>(&descriptor_indexing_features);
+
+			vkb::DeviceBuilder device_builder(phys_dev_ret.value());
+			auto device_ret = device_builder.add_pNext(&phys_dev_feats2).build();
+			REQUIRE(device_ret.error() ==
+			        vkb::DeviceError::VkPhysicalDeviceFeatures2_in_pNext_chain_while_using_add_required_extension_features);
+		}
+
 		vkb::destroy_instance(instance);
 	}
 }
@@ -595,8 +640,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 	GIVEN("A working instance") {
 		vkb::InstanceBuilder builder;
 		auto instance = get_headless_instance(2); // make sure we use 1.2
-		// Requires a device that supports multiview and bufferDeviceAddress
-		{
+		SECTION("Requires a device that supports multiview and bufferDeviceAddress") {
 			VkPhysicalDeviceVulkan11Features features_11{};
 			features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 			features_11.multiview = true;
@@ -614,8 +658,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 			REQUIRE(device_ret.has_value());
 			vkb::destroy_device(device_ret.value());
 		}
-		// protectedMemory should NOT be supported
-		{
+		SECTION("protectedMemory should NOT be supported") {
 			VkPhysicalDeviceVulkan11Features features_11{};
 			features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
 			features_11.protectedMemory = true;


### PR DESCRIPTION
If an application uses add_required_extension_features but also adds
a VkPhysicalDeviceFeatures2 to the pNext chain of VkDeviceCreateInfo,
this will now result in an error. The reason is that Vk-Bootstrap is
perfectly capable of adding VkPhysicalDeviceFeatures to the pNext
chain itself but only if the user didn't already add their own.

Fixes #179 
