### PR TITLE
Fixed instance layer ordering causing validation layer issues with VK_LAYER_KHRONOS_shader_object

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -634,12 +634,12 @@ Result<Instance> InstanceBuilder::build() const {
         return make_error_code(InstanceError::requested_extensions_not_present);
     }
 
-    for (auto& layer : info.layers)
-        layers.push_back(layer);
-
     if (info.enable_validation_layers || (info.request_validation_layers && system.validation_layers_available)) {
         layers.push_back(detail::validation_layer_name);
     }
+    for (auto& layer : info.layers)
+        layers.push_back(layer);
+
     bool all_layers_supported = detail::check_layers_supported(system.available_layers, layers);
     if (!all_layers_supported) {
         return make_error_code(InstanceError::requested_layers_not_present);


### PR DESCRIPTION
Before this fix, enabling the `VK_LAYER_KHRONOS_shader_object` extension layer caused erroneous validation errors to pop up, seemingly as if the validation layers were not aware that the layer was enabled. Changing the order of the layers when building the instance fixed the issue.

For example, before this fix the validation layers would complain about the `VkStructureType` of `vk::PhysicalDeviceShaderObjectFeaturesEXT`  being a completely different type presumably because it doesn't recognize `VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT`.

My code:
```cpp
    vkb::PhysicalDevice vkbPhysicalDevice = physicalDeviceSelector
            .set_minimum_version(1, 3)
            .add_required_extension(VK_EXT_SHADER_OBJECT_EXTENSION_NAME)
            .add_required_extension_features(vk::PhysicalDeviceShaderObjectFeaturesEXT { .shaderObject = true })
            .set_surface(rawSurface)
            .select()
            .value();
```
Error:
```
Validation Error: [ VUID-VkDeviceCreateInfo-pNext-pNext ] | MessageID = 0x901f59ec | vkCreateDevice: pCreateInfo->pNext
chain includes a structure with unexpected VkStructureType VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO; Allowed stru
ctures are [VkDeviceDeviceMemoryReportCreateInfoEXT, VkDeviceDiagnosticsConfigCreateInfoNV, VkDeviceGroupDeviceCreateInf
o, VkDeviceMemoryOverallocationCreateInfoAMD, VkDevicePrivateDataCreateInfo, VkPhysicalDevice16BitStorageFeatures, VkPhy
sicalDevice4444FormatsFeaturesEXT, VkPhysicalDevice8BitStorageFeatures, VkPhysicalDeviceASTCDecodeFeaturesEXT...
]. This error is based on the Valid Usage documentation for version 2
61 of the Vulkan header.  It is possible that you are using a struct from a private extension or an extension that was a
dded to a later version of the Vulkan header, in which case the use of pCreateInfo->pNext is undefined and may not work
correctly with validation enabled The Vulkan spec states: Each pNext member of any structure (including this one) in the
 pNext chain must be either NULL or a pointer to a valid instance of VkDeviceDeviceMemoryReportCreateInfoEXT, VkDeviceDi
agnosticsConfigCreateInfoNV...
```

I haven't tested if similar problems occur with the other extension layers, but hopefully this will fix those too if that was the case.