### PR TITLE
Fix API of CustomQueueDescription

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1437,10 +1437,8 @@ DispatchTable Device::make_table() const { return { device, fp_vkGetDeviceProcAd
 
 Device::operator VkDevice() const { return this->device; }
 
-CustomQueueDescription::CustomQueueDescription(uint32_t index, uint32_t count, std::vector<float> priorities)
-: index(index), count(count), priorities(priorities) {
-    assert(count == priorities.size());
-}
+CustomQueueDescription::CustomQueueDescription(uint32_t index, std::vector<float> priorities)
+: index(index), priorities(priorities) {}
 
 void destroy_device(Device device) {
     device.internal_table.fp_vkDestroyDevice(device.device, device.allocation_callbacks);
@@ -1455,7 +1453,7 @@ Result<Device> DeviceBuilder::build() const {
 
     if (queue_descriptions.size() == 0) {
         for (uint32_t i = 0; i < physical_device.queue_families.size(); i++) {
-            queue_descriptions.push_back(CustomQueueDescription{ i, 1, std::vector<float>{ 1.0f } });
+            queue_descriptions.push_back(CustomQueueDescription{ i, std::vector<float>{ 1.0f } });
         }
     }
 
@@ -1464,7 +1462,7 @@ Result<Device> DeviceBuilder::build() const {
         VkDeviceQueueCreateInfo queue_create_info = {};
         queue_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queue_create_info.queueFamilyIndex = desc.index;
-        queue_create_info.queueCount = desc.count;
+        queue_create_info.queueCount = static_cast<std::uint32_t>(desc.priorities.size());
         queue_create_info.pQueuePriorities = desc.priorities.data();
         queueCreateInfos.push_back(queue_create_info);
     }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -719,9 +719,8 @@ struct Device {
 
 // For advanced device queue setup
 struct CustomQueueDescription {
-    explicit CustomQueueDescription(uint32_t index, uint32_t count, std::vector<float> priorities);
+    explicit CustomQueueDescription(uint32_t index, std::vector<float> priorities);
     uint32_t index = 0;
-    uint32_t count = 0;
     std::vector<float> priorities;
 };
 

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -209,8 +209,8 @@ TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
         auto queue_families = phys_device.get_queue_families();
         for (uint32_t i = 0; i < (uint32_t)queue_families.size(); i++) {
             if (queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-                queue_descriptions.push_back(vkb::CustomQueueDescription(
-                    i, queue_families[i].queueCount, std::vector<float>(queue_families[i].queueCount, 1.0f)));
+                queue_descriptions.push_back(
+                    vkb::CustomQueueDescription(i, std::vector<float>(queue_families[i].queueCount, 1.0f)));
             }
         }
         if (phys_device.has_dedicated_compute_queue()) {
@@ -218,15 +218,15 @@ TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
                 if ((queue_families[i].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
                     (queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0 &&
                     (queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0)
-                    queue_descriptions.push_back(vkb::CustomQueueDescription(
-                        i, queue_families[i].queueCount, std::vector<float>(queue_families[i].queueCount, 1.0f)));
+                    queue_descriptions.push_back(
+                        vkb::CustomQueueDescription(i, std::vector<float>(queue_families[i].queueCount, 1.0f)));
             }
         } else if (phys_device.has_separate_compute_queue()) {
             for (uint32_t i = 0; i < (uint32_t)queue_families.size(); i++) {
                 if ((queue_families[i].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
                     ((queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0)) {
-                    queue_descriptions.push_back(vkb::CustomQueueDescription(
-                        i, queue_families[i].queueCount, std::vector<float>(queue_families[i].queueCount, 1.0f)));
+                    queue_descriptions.push_back(
+                        vkb::CustomQueueDescription(i, std::vector<float>(queue_families[i].queueCount, 1.0f)));
                 }
             }
         }


### PR DESCRIPTION
Issue: `vkb::CustomQueueDescription` provides an interface that allows a mismatch between the size priorities vector and the count of queues.  This allows the user to provide a vector that is too small (and have a memory read out of bounds), or allows the user to provide a vector that is larger than the count and expect all elements in the vector to be used.

Solution: To solve this, we break the API.  Instead of consuming both a count and a vector, `vk-bootstrap` will use the size of the vector to determine queue count.  While it's not typically a good thing to break the API, this provides us a mechanism to make VKB safer with a trivial fix for code consuming this.