### PR TITLE
Add PhysicalDevice::is_extension_present()

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1369,6 +1369,11 @@ bool PhysicalDevice::has_separate_transfer_queue() const {
 }
 std::vector<VkQueueFamilyProperties> PhysicalDevice::get_queue_families() const { return queue_families; }
 std::vector<std::string> PhysicalDevice::get_extensions() const { return extensions; }
+bool PhysicalDevice::is_extension_present(const char* ext) const {
+    return std::find_if(std::begin(extensions), std::end(extensions), [ext](std::string const& ext_name) {
+        return ext_name == ext;
+    }) != std::end(extensions);
+}
 PhysicalDevice::operator VkPhysicalDevice() const { return this->physical_device; }
 
 // ---- Queues ---- //

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -495,6 +495,9 @@ struct PhysicalDevice {
     // Query the list of extensions which should be enabled
     std::vector<std::string> get_extensions() const;
 
+    // Returns true if an extension should be enabled on the device
+    bool is_extension_present(const char* extension) const;
+
     // A conversion function which allows this PhysicalDevice to be used
     // in places where VkPhysicalDevice would have been used.
     operator VkPhysicalDevice() const;

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -113,6 +113,9 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
                                     .set_minimum_version(1, 0)
                                     .select();
             REQUIRE(phys_dev_ret.has_value());
+
+            REQUIRE(phys_dev_ret->is_extension_present(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME));
+            REQUIRE(!phys_dev_ret->is_extension_present(VK_KHR_16BIT_STORAGE_EXTENSION_NAME));
         }
 
         vkb::destroy_surface(instance, surface);


### PR DESCRIPTION
Convenience function to check if a given extension would be enabled on the physical device.

Fixes #199 