### PR TITLE
Add deprecation notice to "desired" requests

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -580,9 +580,9 @@ class PhysicalDeviceSelector {
     PhysicalDeviceSelector& add_required_extensions(std::vector<const char*> extensions);
 
     // Prefer a physical device which supports a specific extension.
-    PhysicalDeviceSelector& add_desired_extension(const char* extension);
+    [[deprecated]] PhysicalDeviceSelector& add_desired_extension(const char* extension);
     // Prefer a physical device which supports a set of extensions.
-    PhysicalDeviceSelector& add_desired_extensions(std::vector<const char*> extensions);
+    [[deprecated]] PhysicalDeviceSelector& add_desired_extensions(std::vector<const char*> extensions);
 
     // Prefer a physical device that supports a (major, minor) version of vulkan.
     [[deprecated("Use set_minimum_version + InstanceBuilder::require_api_version.")]] PhysicalDeviceSelector&
@@ -824,10 +824,10 @@ class SwapchainBuilder {
 
     // Desired size of the swapchain. By default, the swapchain will use the size
     // of the window being drawn to.
-    SwapchainBuilder& set_desired_extent(uint32_t width, uint32_t height);
+    [[deprecated]] SwapchainBuilder& set_desired_extent(uint32_t width, uint32_t height);
 
     // When determining the surface format, make this the first to be used if supported.
-    SwapchainBuilder& set_desired_format(VkSurfaceFormatKHR format);
+    [[deprecated]] SwapchainBuilder& set_desired_format(VkSurfaceFormatKHR format);
     // Add this swapchain format to the end of the list of formats selected from.
     SwapchainBuilder& add_fallback_format(VkSurfaceFormatKHR format);
     // Use the default swapchain formats. This is done if no formats are provided.
@@ -835,7 +835,7 @@ class SwapchainBuilder {
     SwapchainBuilder& use_default_format_selection();
 
     // When determining the present mode, make this the first to be used if supported.
-    SwapchainBuilder& set_desired_present_mode(VkPresentModeKHR present_mode);
+    [[deprecated]] SwapchainBuilder& set_desired_present_mode(VkPresentModeKHR present_mode);
     // Add this present mode to the end of the list of present modes selected from.
     SwapchainBuilder& add_fallback_present_mode(VkPresentModeKHR present_mode);
     // Use the default presentation mode. This is done if no present modes are provided.
@@ -867,7 +867,7 @@ class SwapchainBuilder {
     // Note that the presentation engine is always free to create more images than requested.
     // You may pass one of the values specified in the BufferMode enum, or any integer value.
     // For instance, if you pass DOUBLE_BUFFERING, the presentation engine is allowed to give you a double buffering setup, triple buffering, or more. This is up to the drivers.
-    SwapchainBuilder& set_desired_min_image_count(uint32_t min_image_count);
+    [[deprecated]] SwapchainBuilder& set_desired_min_image_count(uint32_t min_image_count);
 
     // Sets a required minimum image count for the swapchain.
     // If the surface capabilities cannot allow it, building the swapchain will result in the `SwapchainError::required_min_image_count_too_low` error.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,12 @@ target_link_libraries(vk-bootstrap-test
     Catch2::Catch2WithMain
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(vk-bootstrap-test PRIVATE -Wno-error=deprecated-declarations)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(vk-bootstrap-test PRIVATE /wd4996)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)


### PR DESCRIPTION
The ability to request that some physical device or swapchain has certain features but not require said features leads to confusion due to users having to manually check if any desired request succeeded or not. Thus, this feature is being deprecated, with eventual removal in the future.