### PR TITLE
Add enable_extension_if_present to vkb::PhysicalDevice

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -495,8 +495,15 @@ struct PhysicalDevice {
     // Query the list of extensions which should be enabled
     std::vector<std::string> get_extensions() const;
 
+    // Query the list of extensions which the physical device supports
+    std::vector<std::string> get_available_extensions() const;
+
     // Returns true if an extension should be enabled on the device
     bool is_extension_present(const char* extension) const;
+
+    // If the given extension is present, make the extension be enabled on the device.
+    // Returns true the extension is present.
+    bool enable_extension_if_present(const char* extension);
 
     // A conversion function which allows this PhysicalDevice to be used
     // in places where VkPhysicalDevice would have been used.
@@ -504,7 +511,8 @@ struct PhysicalDevice {
 
     private:
     uint32_t instance_version = VKB_VK_API_VERSION_1_0;
-    std::vector<std::string> extensions;
+    std::vector<std::string> extensions_to_enable;
+    std::vector<std::string> available_extensions;
     std::vector<VkQueueFamilyProperties> queue_families;
     std::vector<detail::GenericFeaturesPNextNode> extended_features_chain;
     VkPhysicalDeviceFeatures2 features2{};
@@ -575,7 +583,7 @@ class PhysicalDeviceSelector {
     // Require a memory heap from VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT with `size` memory available.
     PhysicalDeviceSelector& required_device_memory_size(VkDeviceSize size);
     // Prefer a memory heap from VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT with `size` memory available.
-    PhysicalDeviceSelector& desired_device_memory_size(VkDeviceSize size);
+    [[deprecated]] PhysicalDeviceSelector& desired_device_memory_size(VkDeviceSize size);
 
     // Require a physical device which supports a specific extension.
     PhysicalDeviceSelector& add_required_extension(const char* extension);

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -73,6 +73,7 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_multiview"));
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_driver_properties"));
+    mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_EXT_robustness2"));
     auto surface = mock.get_new_surface(get_basic_surface_details());
     GIVEN("A window and a vulkan instance") {
 
@@ -116,6 +117,13 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
 
             REQUIRE(phys_dev_ret->is_extension_present(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME));
             REQUIRE(!phys_dev_ret->is_extension_present(VK_KHR_16BIT_STORAGE_EXTENSION_NAME));
+
+            REQUIRE(phys_dev_ret->enable_extension_if_present(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME));
+            REQUIRE(!phys_dev_ret->enable_extension_if_present(VK_KHR_16BIT_STORAGE_EXTENSION_NAME));
+
+            auto device_ret = vkb::DeviceBuilder(phys_dev_ret.value()).build();
+            REQUIRE(device_ret.has_value());
+            vkb::destroy_device(device_ret.value());
         }
 
         vkb::destroy_surface(instance, surface);


### PR DESCRIPTION
If the given extension is present, enable_extension_if_present will make the extension be enabled on the device.

This fixes a gap in capability due to the deprecation of add_desired_extension.