### PR TITLE
Fix wrong parameter in Wayland function

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -327,6 +327,9 @@ def create_dispatch_table(dispatch_type):
                 elif text == '**':
                     front_mods = ''
                     back_mods = '** '
+                elif text == 'struct*':
+                    front_mods = 'struct '
+                    back_mods = '* '
                 elif text == 'struct**':
                     front_mods = 'struct '
                     back_mods = '** '

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -402,7 +402,7 @@ struct InstanceDispatchTable {
     }
 #endif
 #if (defined(VK_KHR_wayland_surface))
-    VkBool32 getPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, wl_display display) const noexcept {
+    VkBool32 getPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, struct wl_display* display) const noexcept {
         return fp_vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display);
     }
 #endif
@@ -462,7 +462,7 @@ struct InstanceDispatchTable {
     }
 #endif
 #if (defined(VK_QNX_screen_surface))
-    VkBool32 getPhysicalDeviceScreenPresentationSupportQNX(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, _screen_window window) const noexcept {
+    VkBool32 getPhysicalDeviceScreenPresentationSupportQNX(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, struct _screen_window* window) const noexcept {
         return fp_vkGetPhysicalDeviceScreenPresentationSupportQNX(physicalDevice, queueFamilyIndex, window);
     }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(vk-bootstrap-test
     bootstrap_tests.cpp
     error_code_tests.cpp
     unit_tests.cpp
+    include_checks.cpp
 )
 
 target_link_libraries(vk-bootstrap-test

--- a/tests/include_checks.cpp
+++ b/tests/include_checks.cpp
@@ -1,0 +1,26 @@
+
+// Enable the platform specific parts of the API
+#if defined(__ANDROID__)
+#define VK_USE_PLATFORM_ANDROID_KHR
+#endif
+
+#if defined(__APPLE__)
+#define VK_USE_PLATFORM_IOS_MVK
+#define VK_USE_PLATFORM_MACOS_MVK
+#define VK_USE_PLATFORM_METAL_EXT
+#endif
+
+#if defined(WIN32)
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+
+#if defined(__linux__)
+#define VK_USE_PLATFORM_WAYLAND_KHR
+#define VK_USE_PLATFORM_XCB_KHR
+#define VK_USE_PLATFORM_XLIB_KHR
+#define VK_USE_PLATFORM_XLIB_XRANDR_EXT
+#endif
+
+#define VK_ENABLE_BETA_EXTENSIONS
+
+#include "VkBootstrap.h"


### PR DESCRIPTION
Generator script was missing a case - causing incorrect code gen resulting in a compiler errror for wayland.