### PR TITLE
Mark QUEUE_INDEX_MAX_VALUE as inline

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -692,7 +692,7 @@ enum class QueueType { present, graphics, compute, transfer };
 
 namespace detail {
 // Sentinel value, used in implementation only
-const uint32_t QUEUE_INDEX_MAX_VALUE = 65536;
+inline const uint32_t QUEUE_INDEX_MAX_VALUE = 65536;
 } // namespace detail
 
 // ---- Device ---- //


### PR DESCRIPTION
Fixes issues putting VkBootstrap.h into modules.

Fixes #195 