### PR TITLE
Add size + ptr & vector overloads for add_extensions

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -776,6 +776,19 @@ InstanceBuilder& InstanceBuilder::enable_extension(const char* extension_name) {
     info.extensions.push_back(extension_name);
     return *this;
 }
+InstanceBuilder& InstanceBuilder::enable_extensions(std::vector<const char*> const& extensions) {
+    for (const auto extension : extensions) {
+        info.extensions.push_back(extension);
+    }
+    return *this;
+}
+InstanceBuilder& InstanceBuilder::enable_extensions(size_t count, const char* const* extensions) {
+    if (!extensions || count == 0) return *this;
+    for (size_t i = 0; i < count; i++) {
+        info.extensions.push_back(extensions[i]);
+    }
+    return *this;
+}
 InstanceBuilder& InstanceBuilder::enable_validation_layers(bool enable_validation) {
     info.enable_validation_layers = enable_validation;
     return *this;
@@ -1294,9 +1307,16 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extension(const cha
     criteria.required_extensions.push_back(extension);
     return *this;
 }
-PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extensions(std::vector<const char*> extensions) {
+PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extensions(std::vector<const char*> const& extensions) {
     for (const auto& ext : extensions) {
         criteria.required_extensions.push_back(ext);
+    }
+    return *this;
+}
+PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extensions(size_t count, const char* const* extensions) {
+    if (!extensions || count == 0) return *this;
+    for (size_t i = 0; i < count; i++) {
+        criteria.required_extensions.push_back(extensions[i]);
     }
     return *this;
 }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -377,6 +377,8 @@ class InstanceBuilder {
     InstanceBuilder& enable_layer(const char* layer_name);
     // Adds an extension to be enabled. Will fail to create an instance if the extension isn't available.
     InstanceBuilder& enable_extension(const char* extension_name);
+    InstanceBuilder& enable_extensions(std::vector<const char*> const& extensions);
+    InstanceBuilder& enable_extensions(size_t count, const char* const* extensions);
 
     // Headless Mode does not load the required extensions for presentation. Defaults to true.
     InstanceBuilder& set_headless(bool headless = true);
@@ -590,7 +592,8 @@ class PhysicalDeviceSelector {
     // Require a physical device which supports a specific extension.
     PhysicalDeviceSelector& add_required_extension(const char* extension);
     // Require a physical device which supports a set of extensions.
-    PhysicalDeviceSelector& add_required_extensions(std::vector<const char*> extensions);
+    PhysicalDeviceSelector& add_required_extensions(std::vector<const char*> const& extensions);
+    PhysicalDeviceSelector& add_required_extensions(size_t count, const char* const* extensions);
 
     // Prefer a physical device which supports a specific extension.
     [[deprecated]] PhysicalDeviceSelector& add_desired_extension(const char* extension);


### PR DESCRIPTION
The instance & physical device selector only allowed adding a single extension at a time. This commit adds overloads for a vector of const char*'s and a count + pointer pair.

Fixes #224 