### PR TITLE
Fix aliased types not being generated

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -160,9 +160,9 @@ for command_node in commands_node:
         aliases[command_node['@alias']] = command_node['@name']
 
 # Push the alias name as a device function if the alias exists in device commands
-for alias_name, alias in aliases.items():
-    if alias in commands:
-        commands[alias] = copy.deepcopy(commands[alias_name])
+for aliased_type, alias in aliases.items():
+    if aliased_type in commands:
+        commands[alias] = copy.deepcopy(commands[aliased_type])
         commands[alias]['is_alias'] = True
 
 # Add requirements for core PFN's

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -289,6 +289,45 @@ struct InstanceDispatchTable {
 #if (defined(VK_KHR_cooperative_matrix))
         fp_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR>(procAddr(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"));
 #endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(procAddr(instance, "vkGetPhysicalDeviceFeatures2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceProperties2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceFormatProperties2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceImageFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceImageFormatProperties2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceQueueFamilyProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceQueueFamilyProperties2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceMemoryProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceMemoryProperties2KHR"));
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+        fp_vkGetPhysicalDeviceSparseImageFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR>(procAddr(instance, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR"));
+#endif
+#if (defined(VK_KHR_external_memory_capabilities))
+        fp_vkGetPhysicalDeviceExternalBufferPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>(procAddr(instance, "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
+#endif
+#if (defined(VK_KHR_external_semaphore_capabilities))
+        fp_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(procAddr(instance, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"));
+#endif
+#if (defined(VK_KHR_external_fence_capabilities))
+        fp_vkGetPhysicalDeviceExternalFencePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>(procAddr(instance, "vkGetPhysicalDeviceExternalFencePropertiesKHR"));
+#endif
+#if (defined(VK_KHR_device_group_creation))
+        fp_vkEnumeratePhysicalDeviceGroupsKHR = reinterpret_cast<PFN_vkEnumeratePhysicalDeviceGroupsKHR>(procAddr(instance, "vkEnumeratePhysicalDeviceGroupsKHR"));
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+        fp_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = reinterpret_cast<PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT>(procAddr(instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT"));
+#endif
+#if (defined(VK_EXT_tooling_info))
+        fp_vkGetPhysicalDeviceToolPropertiesEXT = reinterpret_cast<PFN_vkGetPhysicalDeviceToolPropertiesEXT>(procAddr(instance, "vkGetPhysicalDeviceToolPropertiesEXT"));
+#endif
     }
     void destroyInstance(const VkAllocationCallbacks* pAllocator) const noexcept {
         fp_vkDestroyInstance(instance, pAllocator);
@@ -741,6 +780,71 @@ struct InstanceDispatchTable {
         return fp_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     }
 #endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2KHR* pFeatures) const noexcept {
+        fp_vkGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2KHR* pProperties) const noexcept {
+        fp_vkGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkFormat format, VkFormatProperties2KHR* pFormatProperties) const noexcept {
+        fp_vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    VkResult getPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2KHR* pImageFormatInfo, VkImageFormatProperties2KHR* pImageFormatProperties) const noexcept {
+        return fp_vkGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) const noexcept {
+        fp_vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceMemoryProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties2KHR* pMemoryProperties) const noexcept {
+        fp_vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties);
+    }
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    void getPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, uint32_t* pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties) const noexcept {
+        fp_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
+    }
+#endif
+#if (defined(VK_KHR_external_memory_capabilities))
+    void getPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfoKHR* pExternalBufferInfo, VkExternalBufferPropertiesKHR* pExternalBufferProperties) const noexcept {
+        fp_vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
+    }
+#endif
+#if (defined(VK_KHR_external_semaphore_capabilities))
+    void getPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalSemaphoreInfoKHR* pExternalSemaphoreInfo, VkExternalSemaphorePropertiesKHR* pExternalSemaphoreProperties) const noexcept {
+        fp_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
+    }
+#endif
+#if (defined(VK_KHR_external_fence_capabilities))
+    void getPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalFenceInfoKHR* pExternalFenceInfo, VkExternalFencePropertiesKHR* pExternalFenceProperties) const noexcept {
+        fp_vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
+    }
+#endif
+#if (defined(VK_KHR_device_group_creation))
+    VkResult enumeratePhysicalDeviceGroupsKHR(uint32_t* pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties) const noexcept {
+        return fp_vkEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+    }
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+    VkResult getPhysicalDeviceCalibrateableTimeDomainsEXT(VkPhysicalDevice physicalDevice, uint32_t* pTimeDomainCount, VkTimeDomainEXT* pTimeDomains) const noexcept {
+        return fp_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains);
+    }
+#endif
+#if (defined(VK_EXT_tooling_info))
+    VkResult getPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t* pToolCount, VkPhysicalDeviceToolPropertiesEXT* pToolProperties) const noexcept {
+        return fp_vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
+    }
+#endif
     PFN_vkDestroyInstance fp_vkDestroyInstance = nullptr;
     PFN_vkEnumeratePhysicalDevices fp_vkEnumeratePhysicalDevices = nullptr;
     PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr = nullptr;
@@ -1167,6 +1271,71 @@ struct InstanceDispatchTable {
     PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR fp_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR = nullptr;
 #else
     void * fp_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceFeatures2KHR fp_vkGetPhysicalDeviceFeatures2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceFeatures2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceProperties2KHR fp_vkGetPhysicalDeviceProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceProperties2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceFormatProperties2KHR fp_vkGetPhysicalDeviceFormatProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceFormatProperties2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR fp_vkGetPhysicalDeviceImageFormatProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceImageFormatProperties2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR fp_vkGetPhysicalDeviceQueueFamilyProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceQueueFamilyProperties2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceMemoryProperties2KHR fp_vkGetPhysicalDeviceMemoryProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceMemoryProperties2KHR{};
+#endif
+#if (defined(VK_KHR_get_physical_device_properties2))
+    PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR fp_vkGetPhysicalDeviceSparseImageFormatProperties2KHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceSparseImageFormatProperties2KHR{};
+#endif
+#if (defined(VK_KHR_external_memory_capabilities))
+    PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR fp_vkGetPhysicalDeviceExternalBufferPropertiesKHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceExternalBufferPropertiesKHR{};
+#endif
+#if (defined(VK_KHR_external_semaphore_capabilities))
+    PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR fp_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR{};
+#endif
+#if (defined(VK_KHR_external_fence_capabilities))
+    PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR fp_vkGetPhysicalDeviceExternalFencePropertiesKHR = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceExternalFencePropertiesKHR{};
+#endif
+#if (defined(VK_KHR_device_group_creation))
+    PFN_vkEnumeratePhysicalDeviceGroupsKHR fp_vkEnumeratePhysicalDeviceGroupsKHR = nullptr;
+#else
+    void * fp_vkEnumeratePhysicalDeviceGroupsKHR{};
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+    PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT fp_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT{};
+#endif
+#if (defined(VK_EXT_tooling_info))
+    PFN_vkGetPhysicalDeviceToolPropertiesEXT fp_vkGetPhysicalDeviceToolPropertiesEXT = nullptr;
+#else
+    void * fp_vkGetPhysicalDeviceToolPropertiesEXT{};
 #endif
     bool is_populated() const { return populated; }
     VkInstance instance = VK_NULL_HANDLE;
@@ -2435,6 +2604,207 @@ struct DispatchTable {
 #endif
 #if (defined(VK_NV_low_latency2))
         fp_vkQueueNotifyOutOfBandNV = reinterpret_cast<PFN_vkQueueNotifyOutOfBandNV>(procAddr(device, "vkQueueNotifyOutOfBandNV"));
+#endif
+#if (defined(VK_EXT_host_query_reset))
+        fp_vkResetQueryPoolEXT = reinterpret_cast<PFN_vkResetQueryPoolEXT>(procAddr(device, "vkResetQueryPoolEXT"));
+#endif
+#if (defined(VK_KHR_maintenance1))
+        fp_vkTrimCommandPoolKHR = reinterpret_cast<PFN_vkTrimCommandPoolKHR>(procAddr(device, "vkTrimCommandPoolKHR"));
+#endif
+#if (defined(VK_KHR_device_group))
+        fp_vkGetDeviceGroupPeerMemoryFeaturesKHR = reinterpret_cast<PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR>(procAddr(device, "vkGetDeviceGroupPeerMemoryFeaturesKHR"));
+#endif
+#if (defined(VK_KHR_bind_memory2))
+        fp_vkBindBufferMemory2KHR = reinterpret_cast<PFN_vkBindBufferMemory2KHR>(procAddr(device, "vkBindBufferMemory2KHR"));
+#endif
+#if (defined(VK_KHR_bind_memory2))
+        fp_vkBindImageMemory2KHR = reinterpret_cast<PFN_vkBindImageMemory2KHR>(procAddr(device, "vkBindImageMemory2KHR"));
+#endif
+#if (defined(VK_KHR_device_group))
+        fp_vkCmdSetDeviceMaskKHR = reinterpret_cast<PFN_vkCmdSetDeviceMaskKHR>(procAddr(device, "vkCmdSetDeviceMaskKHR"));
+#endif
+#if (defined(VK_KHR_device_group))
+        fp_vkCmdDispatchBaseKHR = reinterpret_cast<PFN_vkCmdDispatchBaseKHR>(procAddr(device, "vkCmdDispatchBaseKHR"));
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+        fp_vkCreateDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkCreateDescriptorUpdateTemplateKHR>(procAddr(device, "vkCreateDescriptorUpdateTemplateKHR"));
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+        fp_vkDestroyDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkDestroyDescriptorUpdateTemplateKHR>(procAddr(device, "vkDestroyDescriptorUpdateTemplateKHR"));
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+        fp_vkUpdateDescriptorSetWithTemplateKHR = reinterpret_cast<PFN_vkUpdateDescriptorSetWithTemplateKHR>(procAddr(device, "vkUpdateDescriptorSetWithTemplateKHR"));
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+        fp_vkGetBufferMemoryRequirements2KHR = reinterpret_cast<PFN_vkGetBufferMemoryRequirements2KHR>(procAddr(device, "vkGetBufferMemoryRequirements2KHR"));
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+        fp_vkGetImageMemoryRequirements2KHR = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(procAddr(device, "vkGetImageMemoryRequirements2KHR"));
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+        fp_vkGetImageSparseMemoryRequirements2KHR = reinterpret_cast<PFN_vkGetImageSparseMemoryRequirements2KHR>(procAddr(device, "vkGetImageSparseMemoryRequirements2KHR"));
+#endif
+#if (defined(VK_KHR_maintenance4))
+        fp_vkGetDeviceBufferMemoryRequirementsKHR = reinterpret_cast<PFN_vkGetDeviceBufferMemoryRequirementsKHR>(procAddr(device, "vkGetDeviceBufferMemoryRequirementsKHR"));
+#endif
+#if (defined(VK_KHR_maintenance4))
+        fp_vkGetDeviceImageMemoryRequirementsKHR = reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(procAddr(device, "vkGetDeviceImageMemoryRequirementsKHR"));
+#endif
+#if (defined(VK_KHR_maintenance4))
+        fp_vkGetDeviceImageSparseMemoryRequirementsKHR = reinterpret_cast<PFN_vkGetDeviceImageSparseMemoryRequirementsKHR>(procAddr(device, "vkGetDeviceImageSparseMemoryRequirementsKHR"));
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+        fp_vkCreateSamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(procAddr(device, "vkCreateSamplerYcbcrConversionKHR"));
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+        fp_vkDestroySamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(procAddr(device, "vkDestroySamplerYcbcrConversionKHR"));
+#endif
+#if (defined(VK_KHR_maintenance3))
+        fp_vkGetDescriptorSetLayoutSupportKHR = reinterpret_cast<PFN_vkGetDescriptorSetLayoutSupportKHR>(procAddr(device, "vkGetDescriptorSetLayoutSupportKHR"));
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+        fp_vkGetCalibratedTimestampsEXT = reinterpret_cast<PFN_vkGetCalibratedTimestampsEXT>(procAddr(device, "vkGetCalibratedTimestampsEXT"));
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+        fp_vkCreateRenderPass2KHR = reinterpret_cast<PFN_vkCreateRenderPass2KHR>(procAddr(device, "vkCreateRenderPass2KHR"));
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+        fp_vkCmdBeginRenderPass2KHR = reinterpret_cast<PFN_vkCmdBeginRenderPass2KHR>(procAddr(device, "vkCmdBeginRenderPass2KHR"));
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+        fp_vkCmdNextSubpass2KHR = reinterpret_cast<PFN_vkCmdNextSubpass2KHR>(procAddr(device, "vkCmdNextSubpass2KHR"));
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+        fp_vkCmdEndRenderPass2KHR = reinterpret_cast<PFN_vkCmdEndRenderPass2KHR>(procAddr(device, "vkCmdEndRenderPass2KHR"));
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+        fp_vkGetSemaphoreCounterValueKHR = reinterpret_cast<PFN_vkGetSemaphoreCounterValueKHR>(procAddr(device, "vkGetSemaphoreCounterValueKHR"));
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+        fp_vkWaitSemaphoresKHR = reinterpret_cast<PFN_vkWaitSemaphoresKHR>(procAddr(device, "vkWaitSemaphoresKHR"));
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+        fp_vkSignalSemaphoreKHR = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(procAddr(device, "vkSignalSemaphoreKHR"));
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+        fp_vkCmdDrawIndirectCountAMD = reinterpret_cast<PFN_vkCmdDrawIndirectCountAMD>(procAddr(device, "vkCmdDrawIndirectCountAMD"));
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+        fp_vkCmdDrawIndexedIndirectCountAMD = reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountAMD>(procAddr(device, "vkCmdDrawIndexedIndirectCountAMD"));
+#endif
+#if (defined(VK_NV_ray_tracing))
+        fp_vkGetRayTracingShaderGroupHandlesNV = reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesNV>(procAddr(device, "vkGetRayTracingShaderGroupHandlesNV"));
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+        fp_vkGetBufferOpaqueCaptureAddressKHR = reinterpret_cast<PFN_vkGetBufferOpaqueCaptureAddressKHR>(procAddr(device, "vkGetBufferOpaqueCaptureAddressKHR"));
+#endif
+#if (defined(VK_EXT_buffer_device_address))
+        fp_vkGetBufferDeviceAddressEXT = reinterpret_cast<PFN_vkGetBufferDeviceAddressEXT>(procAddr(device, "vkGetBufferDeviceAddressEXT"));
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+        fp_vkGetDeviceMemoryOpaqueCaptureAddressKHR = reinterpret_cast<PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR>(procAddr(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetCullModeEXT = reinterpret_cast<PFN_vkCmdSetCullModeEXT>(procAddr(device, "vkCmdSetCullModeEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetFrontFaceEXT = reinterpret_cast<PFN_vkCmdSetFrontFaceEXT>(procAddr(device, "vkCmdSetFrontFaceEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetPrimitiveTopologyEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveTopologyEXT>(procAddr(device, "vkCmdSetPrimitiveTopologyEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetViewportWithCountEXT = reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(procAddr(device, "vkCmdSetViewportWithCountEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetScissorWithCountEXT = reinterpret_cast<PFN_vkCmdSetScissorWithCountEXT>(procAddr(device, "vkCmdSetScissorWithCountEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdBindVertexBuffers2EXT = reinterpret_cast<PFN_vkCmdBindVertexBuffers2EXT>(procAddr(device, "vkCmdBindVertexBuffers2EXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetDepthTestEnableEXT = reinterpret_cast<PFN_vkCmdSetDepthTestEnableEXT>(procAddr(device, "vkCmdSetDepthTestEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetDepthWriteEnableEXT = reinterpret_cast<PFN_vkCmdSetDepthWriteEnableEXT>(procAddr(device, "vkCmdSetDepthWriteEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetDepthCompareOpEXT = reinterpret_cast<PFN_vkCmdSetDepthCompareOpEXT>(procAddr(device, "vkCmdSetDepthCompareOpEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetDepthBoundsTestEnableEXT = reinterpret_cast<PFN_vkCmdSetDepthBoundsTestEnableEXT>(procAddr(device, "vkCmdSetDepthBoundsTestEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetStencilTestEnableEXT = reinterpret_cast<PFN_vkCmdSetStencilTestEnableEXT>(procAddr(device, "vkCmdSetStencilTestEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetStencilOpEXT = reinterpret_cast<PFN_vkCmdSetStencilOpEXT>(procAddr(device, "vkCmdSetStencilOpEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetRasterizerDiscardEnableEXT = reinterpret_cast<PFN_vkCmdSetRasterizerDiscardEnableEXT>(procAddr(device, "vkCmdSetRasterizerDiscardEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetDepthBiasEnableEXT = reinterpret_cast<PFN_vkCmdSetDepthBiasEnableEXT>(procAddr(device, "vkCmdSetDepthBiasEnableEXT"));
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+        fp_vkCmdSetPrimitiveRestartEnableEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveRestartEnableEXT>(procAddr(device, "vkCmdSetPrimitiveRestartEnableEXT"));
+#endif
+#if (defined(VK_EXT_private_data))
+        fp_vkCreatePrivateDataSlotEXT = reinterpret_cast<PFN_vkCreatePrivateDataSlotEXT>(procAddr(device, "vkCreatePrivateDataSlotEXT"));
+#endif
+#if (defined(VK_EXT_private_data))
+        fp_vkDestroyPrivateDataSlotEXT = reinterpret_cast<PFN_vkDestroyPrivateDataSlotEXT>(procAddr(device, "vkDestroyPrivateDataSlotEXT"));
+#endif
+#if (defined(VK_EXT_private_data))
+        fp_vkSetPrivateDataEXT = reinterpret_cast<PFN_vkSetPrivateDataEXT>(procAddr(device, "vkSetPrivateDataEXT"));
+#endif
+#if (defined(VK_EXT_private_data))
+        fp_vkGetPrivateDataEXT = reinterpret_cast<PFN_vkGetPrivateDataEXT>(procAddr(device, "vkGetPrivateDataEXT"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdCopyBuffer2KHR = reinterpret_cast<PFN_vkCmdCopyBuffer2KHR>(procAddr(device, "vkCmdCopyBuffer2KHR"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdCopyImage2KHR = reinterpret_cast<PFN_vkCmdCopyImage2KHR>(procAddr(device, "vkCmdCopyImage2KHR"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdBlitImage2KHR = reinterpret_cast<PFN_vkCmdBlitImage2KHR>(procAddr(device, "vkCmdBlitImage2KHR"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdCopyBufferToImage2KHR = reinterpret_cast<PFN_vkCmdCopyBufferToImage2KHR>(procAddr(device, "vkCmdCopyBufferToImage2KHR"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdCopyImageToBuffer2KHR = reinterpret_cast<PFN_vkCmdCopyImageToBuffer2KHR>(procAddr(device, "vkCmdCopyImageToBuffer2KHR"));
+#endif
+#if (defined(VK_KHR_copy_commands2))
+        fp_vkCmdResolveImage2KHR = reinterpret_cast<PFN_vkCmdResolveImage2KHR>(procAddr(device, "vkCmdResolveImage2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkCmdSetEvent2KHR = reinterpret_cast<PFN_vkCmdSetEvent2KHR>(procAddr(device, "vkCmdSetEvent2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkCmdResetEvent2KHR = reinterpret_cast<PFN_vkCmdResetEvent2KHR>(procAddr(device, "vkCmdResetEvent2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkCmdWaitEvents2KHR = reinterpret_cast<PFN_vkCmdWaitEvents2KHR>(procAddr(device, "vkCmdWaitEvents2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkCmdPipelineBarrier2KHR = reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(procAddr(device, "vkCmdPipelineBarrier2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkQueueSubmit2KHR = reinterpret_cast<PFN_vkQueueSubmit2KHR>(procAddr(device, "vkQueueSubmit2KHR"));
+#endif
+#if (defined(VK_KHR_synchronization2))
+        fp_vkCmdWriteTimestamp2KHR = reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(procAddr(device, "vkCmdWriteTimestamp2KHR"));
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+        fp_vkCmdBeginRenderingKHR = reinterpret_cast<PFN_vkCmdBeginRenderingKHR>(procAddr(device, "vkCmdBeginRenderingKHR"));
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+        fp_vkCmdEndRenderingKHR = reinterpret_cast<PFN_vkCmdEndRenderingKHR>(procAddr(device, "vkCmdEndRenderingKHR"));
+#endif
+#if (defined(VK_EXT_host_image_copy)) || (defined(VK_EXT_image_compression_control))
+        fp_vkGetImageSubresourceLayout2EXT = reinterpret_cast<PFN_vkGetImageSubresourceLayout2EXT>(procAddr(device, "vkGetImageSubresourceLayout2EXT"));
 #endif
     }
     void getDeviceQueue(uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) const noexcept {
@@ -4694,6 +5064,341 @@ struct DispatchTable {
         fp_vkQueueNotifyOutOfBandNV(queue, pQueueTypeInfo);
     }
 #endif
+#if (defined(VK_EXT_host_query_reset))
+    void resetQueryPoolEXT(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) const noexcept {
+        fp_vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
+    }
+#endif
+#if (defined(VK_KHR_maintenance1))
+    void trimCommandPoolKHR(VkCommandPool commandPool, VkCommandPoolTrimFlagsKHR flags) const noexcept {
+        fp_vkTrimCommandPoolKHR(device, commandPool, flags);
+    }
+#endif
+#if (defined(VK_KHR_device_group))
+    void getDeviceGroupPeerMemoryFeaturesKHR(uint32_t heapIndex, uint32_t localDeviceIndex, uint32_t remoteDeviceIndex, VkPeerMemoryFeatureFlagsKHR* pPeerMemoryFeatures) const noexcept {
+        fp_vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
+    }
+#endif
+#if (defined(VK_KHR_bind_memory2))
+    VkResult bindBufferMemory2KHR(uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos) const noexcept {
+        return fp_vkBindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
+    }
+#endif
+#if (defined(VK_KHR_bind_memory2))
+    VkResult bindImageMemory2KHR(uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos) const noexcept {
+        return fp_vkBindImageMemory2KHR(device, bindInfoCount, pBindInfos);
+    }
+#endif
+#if (defined(VK_KHR_device_group))
+    void cmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) const noexcept {
+        fp_vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask);
+    }
+#endif
+#if (defined(VK_KHR_device_group))
+    void cmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) const noexcept {
+        fp_vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+    }
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    VkResult createDescriptorUpdateTemplateKHR(const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) const noexcept {
+        return fp_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+    }
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    void destroyDescriptorUpdateTemplateKHR(VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) const noexcept {
+        fp_vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
+    }
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    void updateDescriptorSetWithTemplateKHR(VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) const noexcept {
+        fp_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
+    }
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    void getBufferMemoryRequirements2KHR(const VkBufferMemoryRequirementsInfo2KHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) const noexcept {
+        fp_vkGetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    void getImageMemoryRequirements2KHR(const VkImageMemoryRequirementsInfo2KHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) const noexcept {
+        fp_vkGetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    void getImageSparseMemoryRequirements2KHR(const VkImageSparseMemoryRequirementsInfo2KHR* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements) const noexcept {
+        fp_vkGetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_maintenance4))
+    void getDeviceBufferMemoryRequirementsKHR(const VkDeviceBufferMemoryRequirementsKHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) const noexcept {
+        fp_vkGetDeviceBufferMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_maintenance4))
+    void getDeviceImageMemoryRequirementsKHR(const VkDeviceImageMemoryRequirementsKHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) const noexcept {
+        fp_vkGetDeviceImageMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_maintenance4))
+    void getDeviceImageSparseMemoryRequirementsKHR(const VkDeviceImageMemoryRequirementsKHR* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements) const noexcept {
+        fp_vkGetDeviceImageSparseMemoryRequirementsKHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    }
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+    VkResult createSamplerYcbcrConversionKHR(const VkSamplerYcbcrConversionCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSamplerYcbcrConversionKHR* pYcbcrConversion) const noexcept {
+        return fp_vkCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
+    }
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+    void destroySamplerYcbcrConversionKHR(VkSamplerYcbcrConversionKHR ycbcrConversion, const VkAllocationCallbacks* pAllocator) const noexcept {
+        fp_vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
+    }
+#endif
+#if (defined(VK_KHR_maintenance3))
+    void getDescriptorSetLayoutSupportKHR(const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupportKHR* pSupport) const noexcept {
+        fp_vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport);
+    }
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+    VkResult getCalibratedTimestampsEXT(uint32_t timestampCount, const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps, uint64_t* pMaxDeviation) const noexcept {
+        return fp_vkGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
+    }
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    VkResult createRenderPass2KHR(const VkRenderPassCreateInfo2KHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const noexcept {
+        return fp_vkCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
+    }
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    void cmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfoKHR* pSubpassBeginInfo) const noexcept {
+        fp_vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+    }
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    void cmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfoKHR* pSubpassBeginInfo, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
+        fp_vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+    }
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    void cmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassEndInfo) const noexcept {
+        fp_vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+    }
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    VkResult getSemaphoreCounterValueKHR(VkSemaphore semaphore, uint64_t* pValue) const noexcept {
+        return fp_vkGetSemaphoreCounterValueKHR(device, semaphore, pValue);
+    }
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    VkResult waitSemaphoresKHR(const VkSemaphoreWaitInfoKHR* pWaitInfo, uint64_t timeout) const noexcept {
+        return fp_vkWaitSemaphoresKHR(device, pWaitInfo, timeout);
+    }
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    VkResult signalSemaphoreKHR(const VkSemaphoreSignalInfoKHR* pSignalInfo) const noexcept {
+        return fp_vkSignalSemaphoreKHR(device, pSignalInfo);
+    }
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+    void cmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) const noexcept {
+        fp_vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    }
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+    void cmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) const noexcept {
+        fp_vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    }
+#endif
+#if (defined(VK_NV_ray_tracing))
+    VkResult getRayTracingShaderGroupHandlesNV(VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) const noexcept {
+        return fp_vkGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
+    }
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+    uint64_t getBufferOpaqueCaptureAddressKHR(const VkBufferDeviceAddressInfoEXT* pInfo) const noexcept {
+        return fp_vkGetBufferOpaqueCaptureAddressKHR(device, pInfo);
+    }
+#endif
+#if (defined(VK_EXT_buffer_device_address))
+    VkDeviceAddress getBufferDeviceAddressEXT(const VkBufferDeviceAddressInfoEXT* pInfo) const noexcept {
+        return fp_vkGetBufferDeviceAddressEXT(device, pInfo);
+    }
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+    uint64_t getDeviceMemoryOpaqueCaptureAddressKHR(const VkDeviceMemoryOpaqueCaptureAddressInfoKHR* pInfo) const noexcept {
+        return fp_vkGetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) const noexcept {
+        fp_vkCmdSetCullModeEXT(commandBuffer, cullMode);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) const noexcept {
+        fp_vkCmdSetFrontFaceEXT(commandBuffer, frontFace);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology) const noexcept {
+        fp_vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount, const VkViewport* pViewports) const noexcept {
+        fp_vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount, const VkRect2D* pScissors) const noexcept {
+        fp_vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount, const VkBuffer* pBuffers, const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes, const VkDeviceSize* pStrides) const noexcept {
+        fp_vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) const noexcept {
+        fp_vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) const noexcept {
+        fp_vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) const noexcept {
+        fp_vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) const noexcept {
+        fp_vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) const noexcept {
+        fp_vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    void cmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) const noexcept {
+        fp_vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    void cmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable) const noexcept {
+        fp_vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    void cmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) const noexcept {
+        fp_vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
+    }
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    void cmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable) const noexcept {
+        fp_vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
+    }
+#endif
+#if (defined(VK_EXT_private_data))
+    VkResult createPrivateDataSlotEXT(const VkPrivateDataSlotCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkPrivateDataSlotEXT* pPrivateDataSlot) const noexcept {
+        return fp_vkCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot);
+    }
+#endif
+#if (defined(VK_EXT_private_data))
+    void destroyPrivateDataSlotEXT(VkPrivateDataSlotEXT privateDataSlot, const VkAllocationCallbacks* pAllocator) const noexcept {
+        fp_vkDestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
+    }
+#endif
+#if (defined(VK_EXT_private_data))
+    VkResult setPrivateDataEXT(VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlotEXT privateDataSlot, uint64_t data) const noexcept {
+        return fp_vkSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data);
+    }
+#endif
+#if (defined(VK_EXT_private_data))
+    void getPrivateDataEXT(VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlotEXT privateDataSlot, uint64_t* pData) const noexcept {
+        fp_vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo) const noexcept {
+        fp_vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo) const noexcept {
+        fp_vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo) const noexcept {
+        fp_vkCmdBlitImage2KHR(commandBuffer, pBlitImageInfo);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo) const noexcept {
+        fp_vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2KHR* pCopyImageToBufferInfo) const noexcept {
+        fp_vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
+    }
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    void cmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR* pResolveImageInfo) const noexcept {
+        fp_vkCmdResolveImage2KHR(commandBuffer, pResolveImageInfo);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    void cmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR* pDependencyInfo) const noexcept {
+        fp_vkCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    void cmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask) const noexcept {
+        fp_vkCmdResetEvent2KHR(commandBuffer, event, stageMask);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    void cmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfoKHR* pDependencyInfos) const noexcept {
+        fp_vkCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    void cmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR* pDependencyInfo) const noexcept {
+        fp_vkCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    VkResult queueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence) const noexcept {
+        return fp_vkQueueSubmit2KHR(queue, submitCount, pSubmits, fence);
+    }
+#endif
+#if (defined(VK_KHR_synchronization2))
+    void cmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage, VkQueryPool queryPool, uint32_t query) const noexcept {
+        fp_vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
+    }
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+    void cmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo) const noexcept {
+        fp_vkCmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
+    }
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+    void cmdEndRenderingKHR(VkCommandBuffer commandBuffer) const noexcept {
+        fp_vkCmdEndRenderingKHR(commandBuffer);
+    }
+#endif
+#if (defined(VK_EXT_host_image_copy)) || (defined(VK_EXT_image_compression_control))
+    void getImageSubresourceLayout2EXT(VkImage image, const VkImageSubresource2EXT* pSubresource, VkSubresourceLayout2EXT* pLayout) const noexcept {
+        fp_vkGetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
+    }
+#endif
     PFN_vkGetDeviceQueue fp_vkGetDeviceQueue = nullptr;
     PFN_vkQueueSubmit fp_vkQueueSubmit = nullptr;
     PFN_vkQueueWaitIdle fp_vkQueueWaitIdle = nullptr;
@@ -6712,6 +7417,341 @@ struct DispatchTable {
     PFN_vkQueueNotifyOutOfBandNV fp_vkQueueNotifyOutOfBandNV = nullptr;
 #else
     void * fp_vkQueueNotifyOutOfBandNV{};
+#endif
+#if (defined(VK_EXT_host_query_reset))
+    PFN_vkResetQueryPoolEXT fp_vkResetQueryPoolEXT = nullptr;
+#else
+    void * fp_vkResetQueryPoolEXT{};
+#endif
+#if (defined(VK_KHR_maintenance1))
+    PFN_vkTrimCommandPoolKHR fp_vkTrimCommandPoolKHR = nullptr;
+#else
+    void * fp_vkTrimCommandPoolKHR{};
+#endif
+#if (defined(VK_KHR_device_group))
+    PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR fp_vkGetDeviceGroupPeerMemoryFeaturesKHR = nullptr;
+#else
+    void * fp_vkGetDeviceGroupPeerMemoryFeaturesKHR{};
+#endif
+#if (defined(VK_KHR_bind_memory2))
+    PFN_vkBindBufferMemory2KHR fp_vkBindBufferMemory2KHR = nullptr;
+#else
+    void * fp_vkBindBufferMemory2KHR{};
+#endif
+#if (defined(VK_KHR_bind_memory2))
+    PFN_vkBindImageMemory2KHR fp_vkBindImageMemory2KHR = nullptr;
+#else
+    void * fp_vkBindImageMemory2KHR{};
+#endif
+#if (defined(VK_KHR_device_group))
+    PFN_vkCmdSetDeviceMaskKHR fp_vkCmdSetDeviceMaskKHR = nullptr;
+#else
+    void * fp_vkCmdSetDeviceMaskKHR{};
+#endif
+#if (defined(VK_KHR_device_group))
+    PFN_vkCmdDispatchBaseKHR fp_vkCmdDispatchBaseKHR = nullptr;
+#else
+    void * fp_vkCmdDispatchBaseKHR{};
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    PFN_vkCreateDescriptorUpdateTemplateKHR fp_vkCreateDescriptorUpdateTemplateKHR = nullptr;
+#else
+    void * fp_vkCreateDescriptorUpdateTemplateKHR{};
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    PFN_vkDestroyDescriptorUpdateTemplateKHR fp_vkDestroyDescriptorUpdateTemplateKHR = nullptr;
+#else
+    void * fp_vkDestroyDescriptorUpdateTemplateKHR{};
+#endif
+#if (defined(VK_KHR_descriptor_update_template))
+    PFN_vkUpdateDescriptorSetWithTemplateKHR fp_vkUpdateDescriptorSetWithTemplateKHR = nullptr;
+#else
+    void * fp_vkUpdateDescriptorSetWithTemplateKHR{};
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    PFN_vkGetBufferMemoryRequirements2KHR fp_vkGetBufferMemoryRequirements2KHR = nullptr;
+#else
+    void * fp_vkGetBufferMemoryRequirements2KHR{};
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    PFN_vkGetImageMemoryRequirements2KHR fp_vkGetImageMemoryRequirements2KHR = nullptr;
+#else
+    void * fp_vkGetImageMemoryRequirements2KHR{};
+#endif
+#if (defined(VK_KHR_get_memory_requirements2))
+    PFN_vkGetImageSparseMemoryRequirements2KHR fp_vkGetImageSparseMemoryRequirements2KHR = nullptr;
+#else
+    void * fp_vkGetImageSparseMemoryRequirements2KHR{};
+#endif
+#if (defined(VK_KHR_maintenance4))
+    PFN_vkGetDeviceBufferMemoryRequirementsKHR fp_vkGetDeviceBufferMemoryRequirementsKHR = nullptr;
+#else
+    void * fp_vkGetDeviceBufferMemoryRequirementsKHR{};
+#endif
+#if (defined(VK_KHR_maintenance4))
+    PFN_vkGetDeviceImageMemoryRequirementsKHR fp_vkGetDeviceImageMemoryRequirementsKHR = nullptr;
+#else
+    void * fp_vkGetDeviceImageMemoryRequirementsKHR{};
+#endif
+#if (defined(VK_KHR_maintenance4))
+    PFN_vkGetDeviceImageSparseMemoryRequirementsKHR fp_vkGetDeviceImageSparseMemoryRequirementsKHR = nullptr;
+#else
+    void * fp_vkGetDeviceImageSparseMemoryRequirementsKHR{};
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+    PFN_vkCreateSamplerYcbcrConversionKHR fp_vkCreateSamplerYcbcrConversionKHR = nullptr;
+#else
+    void * fp_vkCreateSamplerYcbcrConversionKHR{};
+#endif
+#if (defined(VK_KHR_sampler_ycbcr_conversion))
+    PFN_vkDestroySamplerYcbcrConversionKHR fp_vkDestroySamplerYcbcrConversionKHR = nullptr;
+#else
+    void * fp_vkDestroySamplerYcbcrConversionKHR{};
+#endif
+#if (defined(VK_KHR_maintenance3))
+    PFN_vkGetDescriptorSetLayoutSupportKHR fp_vkGetDescriptorSetLayoutSupportKHR = nullptr;
+#else
+    void * fp_vkGetDescriptorSetLayoutSupportKHR{};
+#endif
+#if (defined(VK_EXT_calibrated_timestamps))
+    PFN_vkGetCalibratedTimestampsEXT fp_vkGetCalibratedTimestampsEXT = nullptr;
+#else
+    void * fp_vkGetCalibratedTimestampsEXT{};
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    PFN_vkCreateRenderPass2KHR fp_vkCreateRenderPass2KHR = nullptr;
+#else
+    void * fp_vkCreateRenderPass2KHR{};
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    PFN_vkCmdBeginRenderPass2KHR fp_vkCmdBeginRenderPass2KHR = nullptr;
+#else
+    void * fp_vkCmdBeginRenderPass2KHR{};
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    PFN_vkCmdNextSubpass2KHR fp_vkCmdNextSubpass2KHR = nullptr;
+#else
+    void * fp_vkCmdNextSubpass2KHR{};
+#endif
+#if (defined(VK_KHR_create_renderpass2))
+    PFN_vkCmdEndRenderPass2KHR fp_vkCmdEndRenderPass2KHR = nullptr;
+#else
+    void * fp_vkCmdEndRenderPass2KHR{};
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    PFN_vkGetSemaphoreCounterValueKHR fp_vkGetSemaphoreCounterValueKHR = nullptr;
+#else
+    void * fp_vkGetSemaphoreCounterValueKHR{};
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    PFN_vkWaitSemaphoresKHR fp_vkWaitSemaphoresKHR = nullptr;
+#else
+    void * fp_vkWaitSemaphoresKHR{};
+#endif
+#if (defined(VK_KHR_timeline_semaphore))
+    PFN_vkSignalSemaphoreKHR fp_vkSignalSemaphoreKHR = nullptr;
+#else
+    void * fp_vkSignalSemaphoreKHR{};
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+    PFN_vkCmdDrawIndirectCountAMD fp_vkCmdDrawIndirectCountAMD = nullptr;
+#else
+    void * fp_vkCmdDrawIndirectCountAMD{};
+#endif
+#if (defined(VK_AMD_draw_indirect_count))
+    PFN_vkCmdDrawIndexedIndirectCountAMD fp_vkCmdDrawIndexedIndirectCountAMD = nullptr;
+#else
+    void * fp_vkCmdDrawIndexedIndirectCountAMD{};
+#endif
+#if (defined(VK_NV_ray_tracing))
+    PFN_vkGetRayTracingShaderGroupHandlesNV fp_vkGetRayTracingShaderGroupHandlesNV = nullptr;
+#else
+    void * fp_vkGetRayTracingShaderGroupHandlesNV{};
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+    PFN_vkGetBufferOpaqueCaptureAddressKHR fp_vkGetBufferOpaqueCaptureAddressKHR = nullptr;
+#else
+    void * fp_vkGetBufferOpaqueCaptureAddressKHR{};
+#endif
+#if (defined(VK_EXT_buffer_device_address))
+    PFN_vkGetBufferDeviceAddressEXT fp_vkGetBufferDeviceAddressEXT = nullptr;
+#else
+    void * fp_vkGetBufferDeviceAddressEXT{};
+#endif
+#if (defined(VK_KHR_buffer_device_address))
+    PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR fp_vkGetDeviceMemoryOpaqueCaptureAddressKHR = nullptr;
+#else
+    void * fp_vkGetDeviceMemoryOpaqueCaptureAddressKHR{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetCullModeEXT fp_vkCmdSetCullModeEXT = nullptr;
+#else
+    void * fp_vkCmdSetCullModeEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetFrontFaceEXT fp_vkCmdSetFrontFaceEXT = nullptr;
+#else
+    void * fp_vkCmdSetFrontFaceEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetPrimitiveTopologyEXT fp_vkCmdSetPrimitiveTopologyEXT = nullptr;
+#else
+    void * fp_vkCmdSetPrimitiveTopologyEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetViewportWithCountEXT fp_vkCmdSetViewportWithCountEXT = nullptr;
+#else
+    void * fp_vkCmdSetViewportWithCountEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetScissorWithCountEXT fp_vkCmdSetScissorWithCountEXT = nullptr;
+#else
+    void * fp_vkCmdSetScissorWithCountEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdBindVertexBuffers2EXT fp_vkCmdBindVertexBuffers2EXT = nullptr;
+#else
+    void * fp_vkCmdBindVertexBuffers2EXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetDepthTestEnableEXT fp_vkCmdSetDepthTestEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetDepthTestEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetDepthWriteEnableEXT fp_vkCmdSetDepthWriteEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetDepthWriteEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetDepthCompareOpEXT fp_vkCmdSetDepthCompareOpEXT = nullptr;
+#else
+    void * fp_vkCmdSetDepthCompareOpEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetDepthBoundsTestEnableEXT fp_vkCmdSetDepthBoundsTestEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetDepthBoundsTestEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetStencilTestEnableEXT fp_vkCmdSetStencilTestEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetStencilTestEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetStencilOpEXT fp_vkCmdSetStencilOpEXT = nullptr;
+#else
+    void * fp_vkCmdSetStencilOpEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetRasterizerDiscardEnableEXT fp_vkCmdSetRasterizerDiscardEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetRasterizerDiscardEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetDepthBiasEnableEXT fp_vkCmdSetDepthBiasEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetDepthBiasEnableEXT{};
+#endif
+#if (defined(VK_EXT_extended_dynamic_state2)) || (defined(VK_EXT_shader_object))
+    PFN_vkCmdSetPrimitiveRestartEnableEXT fp_vkCmdSetPrimitiveRestartEnableEXT = nullptr;
+#else
+    void * fp_vkCmdSetPrimitiveRestartEnableEXT{};
+#endif
+#if (defined(VK_EXT_private_data))
+    PFN_vkCreatePrivateDataSlotEXT fp_vkCreatePrivateDataSlotEXT = nullptr;
+#else
+    void * fp_vkCreatePrivateDataSlotEXT{};
+#endif
+#if (defined(VK_EXT_private_data))
+    PFN_vkDestroyPrivateDataSlotEXT fp_vkDestroyPrivateDataSlotEXT = nullptr;
+#else
+    void * fp_vkDestroyPrivateDataSlotEXT{};
+#endif
+#if (defined(VK_EXT_private_data))
+    PFN_vkSetPrivateDataEXT fp_vkSetPrivateDataEXT = nullptr;
+#else
+    void * fp_vkSetPrivateDataEXT{};
+#endif
+#if (defined(VK_EXT_private_data))
+    PFN_vkGetPrivateDataEXT fp_vkGetPrivateDataEXT = nullptr;
+#else
+    void * fp_vkGetPrivateDataEXT{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdCopyBuffer2KHR fp_vkCmdCopyBuffer2KHR = nullptr;
+#else
+    void * fp_vkCmdCopyBuffer2KHR{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdCopyImage2KHR fp_vkCmdCopyImage2KHR = nullptr;
+#else
+    void * fp_vkCmdCopyImage2KHR{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdBlitImage2KHR fp_vkCmdBlitImage2KHR = nullptr;
+#else
+    void * fp_vkCmdBlitImage2KHR{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdCopyBufferToImage2KHR fp_vkCmdCopyBufferToImage2KHR = nullptr;
+#else
+    void * fp_vkCmdCopyBufferToImage2KHR{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdCopyImageToBuffer2KHR fp_vkCmdCopyImageToBuffer2KHR = nullptr;
+#else
+    void * fp_vkCmdCopyImageToBuffer2KHR{};
+#endif
+#if (defined(VK_KHR_copy_commands2))
+    PFN_vkCmdResolveImage2KHR fp_vkCmdResolveImage2KHR = nullptr;
+#else
+    void * fp_vkCmdResolveImage2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkCmdSetEvent2KHR fp_vkCmdSetEvent2KHR = nullptr;
+#else
+    void * fp_vkCmdSetEvent2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkCmdResetEvent2KHR fp_vkCmdResetEvent2KHR = nullptr;
+#else
+    void * fp_vkCmdResetEvent2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkCmdWaitEvents2KHR fp_vkCmdWaitEvents2KHR = nullptr;
+#else
+    void * fp_vkCmdWaitEvents2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkCmdPipelineBarrier2KHR fp_vkCmdPipelineBarrier2KHR = nullptr;
+#else
+    void * fp_vkCmdPipelineBarrier2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkQueueSubmit2KHR fp_vkQueueSubmit2KHR = nullptr;
+#else
+    void * fp_vkQueueSubmit2KHR{};
+#endif
+#if (defined(VK_KHR_synchronization2))
+    PFN_vkCmdWriteTimestamp2KHR fp_vkCmdWriteTimestamp2KHR = nullptr;
+#else
+    void * fp_vkCmdWriteTimestamp2KHR{};
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+    PFN_vkCmdBeginRenderingKHR fp_vkCmdBeginRenderingKHR = nullptr;
+#else
+    void * fp_vkCmdBeginRenderingKHR{};
+#endif
+#if (defined(VK_KHR_dynamic_rendering))
+    PFN_vkCmdEndRenderingKHR fp_vkCmdEndRenderingKHR = nullptr;
+#else
+    void * fp_vkCmdEndRenderingKHR{};
+#endif
+#if (defined(VK_EXT_host_image_copy)) || (defined(VK_EXT_image_compression_control))
+    PFN_vkGetImageSubresourceLayout2EXT fp_vkGetImageSubresourceLayout2EXT = nullptr;
+#else
+    void * fp_vkGetImageSubresourceLayout2EXT{};
 #endif
     bool is_populated() const { return populated; }
     VkDevice device = VK_NULL_HANDLE;


### PR DESCRIPTION
Types that are promoted get turned into aliases, but the dispatch table was missing these types. This was due to a simple mistake of mixing up the alias with the type being aliased.

Fix #207 