### PR TITLE
Workaround VK_EXT_discard_rectangles adding new functions

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -102,6 +102,13 @@ commands = {}
 INSTANCE = 'instance'
 DEVICE = 'device'
 
+# No good way to detect incompatibilities with the macro defines and the actual functions. Just keep a list here
+HEADER_VERSION_WORKAROUNDS = {
+    'vkGetLatencyTimingsNV': '271', # Changed API parameters
+    'vkCmdSetDiscardRectangleEnableEXT': '241', # new function in older extension
+    'vkCmdSetDiscardRectangleModeEXT': '241', # new function in older extension
+}
+
 def get_macro_guard(reqs_collection, command_name):
     guard = ''
     count = len(reqs_collection)
@@ -121,8 +128,9 @@ def get_macro_guard(reqs_collection, command_name):
                     if count > 0:
                         guard += ' || '
         # API breaking change causes this function to fail compilation
-        if command_name == 'vkGetLatencyTimingsNV':
-            guard = f'({guard}) && VK_HEADER_VERSION >= 271'
+        for function, version in HEADER_VERSION_WORKAROUNDS.items():
+            if command_name == function:
+                guard = f'({guard}) && VK_HEADER_VERSION >= {version}'
     return guard
 
 

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -1711,10 +1711,10 @@ struct DispatchTable {
 #if (defined(VK_EXT_discard_rectangles))
         fp_vkCmdSetDiscardRectangleEXT = reinterpret_cast<PFN_vkCmdSetDiscardRectangleEXT>(procAddr(device, "vkCmdSetDiscardRectangleEXT"));
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
         fp_vkCmdSetDiscardRectangleEnableEXT = reinterpret_cast<PFN_vkCmdSetDiscardRectangleEnableEXT>(procAddr(device, "vkCmdSetDiscardRectangleEnableEXT"));
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
         fp_vkCmdSetDiscardRectangleModeEXT = reinterpret_cast<PFN_vkCmdSetDiscardRectangleModeEXT>(procAddr(device, "vkCmdSetDiscardRectangleModeEXT"));
 #endif
 #if (defined(VK_EXT_sample_locations))
@@ -3574,12 +3574,12 @@ struct DispatchTable {
         fp_vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
     }
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
     void cmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable) const noexcept {
         fp_vkCmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
     }
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
     void cmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer, VkDiscardRectangleModeEXT discardRectangleMode) const noexcept {
         fp_vkCmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
     }
@@ -5928,12 +5928,12 @@ struct DispatchTable {
 #else
     void * fp_vkCmdSetDiscardRectangleEXT{};
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
     PFN_vkCmdSetDiscardRectangleEnableEXT fp_vkCmdSetDiscardRectangleEnableEXT = nullptr;
 #else
     void * fp_vkCmdSetDiscardRectangleEnableEXT{};
 #endif
-#if (defined(VK_EXT_discard_rectangles))
+#if ((defined(VK_EXT_discard_rectangles))) && VK_HEADER_VERSION >= 241
     PFN_vkCmdSetDiscardRectangleModeEXT fp_vkCmdSetDiscardRectangleModeEXT = nullptr;
 #else
     void * fp_vkCmdSetDiscardRectangleModeEXT{};


### PR DESCRIPTION
Generalize the mechanism to not enable function pointers based on the current header version, due to VK_EXT_discard_rectangles adding functions not present in the original extension.