### PR TITLE
Add const case to parameter parsing in autogen

### DIFF
--- a/script/generate_dispatch.py
+++ b/script/generate_dispatch.py
@@ -332,6 +332,9 @@ def create_dispatch_table(dispatch_type):
                 elif text == 'struct**':
                     front_mods = 'struct '
                     back_mods = '** '
+                elif text == 'const':
+                    front_mods = 'const '
+                    back_mods = ' '
                 elif text == 'const*':
                     front_mods = 'const '
                     back_mods = '* '
@@ -344,6 +347,9 @@ def create_dispatch_table(dispatch_type):
                 elif text == 'conststruct*':
                     front_mods = 'const struct '
                     back_mods = '* '
+                else:
+                    print("Unhandled Text Case!")
+                    assert(False)
             if i == args_count and (dispatch_type == INSTANCE and arg_type == 'VkInstance') or (dispatch_type == DEVICE and arg_type == 'VkDevice'):
                 args_names += arg_name
                 if i > 0:

--- a/src/VkBootstrapDispatch.h
+++ b/src/VkBootstrapDispatch.h
@@ -3085,7 +3085,7 @@ struct DispatchTable {
     void cmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp, float depthBiasSlopeFactor) const noexcept {
         fp_vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     }
-    void cmdSetBlendConstants(VkCommandBuffer commandBuffer, float blendConstants[4]) const noexcept {
+    void cmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) const noexcept {
         fp_vkCmdSetBlendConstants(commandBuffer, blendConstants);
     }
     void cmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds) const noexcept {
@@ -4538,12 +4538,12 @@ struct DispatchTable {
     }
 #endif
 #if (defined(VK_KHR_fragment_shading_rate))
-    void cmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize, VkFragmentShadingRateCombinerOpKHR combinerOps[2]) const noexcept {
+    void cmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize, const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) const noexcept {
         fp_vkCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
     }
 #endif
 #if (defined(VK_NV_fragment_shading_rate_enums))
-    void cmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate, VkFragmentShadingRateCombinerOpKHR combinerOps[2]) const noexcept {
+    void cmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate, const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) const noexcept {
         fp_vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
     }
 #endif


### PR DESCRIPTION
This was missing, causing errors in user code due to not preserving const