### PR TITLE
Enable Extensions If Present

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1399,6 +1399,17 @@ bool PhysicalDevice::enable_extension_if_present(const char* extension) {
     }
     return false;
 }
+bool PhysicalDevice::enable_extensions_if_present(const std::vector<const char*>& extensions) { 
+    for (const auto extension : extensions) {
+        auto it = std::find_if(std::begin(available_extensions),
+            std::end(available_extensions),
+            [extension](std::string const& ext_name) { return ext_name == extension; });
+        if (it == std::end(available_extensions)) return false;
+    }
+    for (const auto extension : extensions)
+        extensions_to_enable.push_back(extension);
+    return true;
+}
 
 PhysicalDevice::operator VkPhysicalDevice() const { return this->physical_device; }
 

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -509,6 +509,10 @@ struct PhysicalDevice {
     // Returns true the extension is present.
     bool enable_extension_if_present(const char* extension);
 
+    // If all the given extensions are present, make all the extensions be enabled on the device.
+    // Returns true if all the extensions are present.
+    bool enable_extensions_if_present(const std::vector<const char*>& extensions);
+
     // A conversion function which allows this PhysicalDevice to be used
     // in places where VkPhysicalDevice would have been used.
     operator VkPhysicalDevice() const;

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -121,6 +121,14 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
             REQUIRE(phys_dev_ret->enable_extension_if_present(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME));
             REQUIRE(!phys_dev_ret->enable_extension_if_present(VK_KHR_16BIT_STORAGE_EXTENSION_NAME));
 
+            const std::vector<const char*> extension_set_1 = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, 
+                VK_EXT_ROBUSTNESS_2_EXTENSION_NAME };
+            const std::vector<const char*> extension_set_2 = { VK_KHR_16BIT_STORAGE_EXTENSION_NAME, 
+                VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME };
+
+            REQUIRE(phys_dev_ret->enable_extensions_if_present(extension_set_1));
+            REQUIRE(!phys_dev_ret->enable_extensions_if_present(extension_set_2));
+
             auto device_ret = vkb::DeviceBuilder(phys_dev_ret.value()).build();
             REQUIRE(device_ret.has_value());
             vkb::destroy_device(device_ret.value());


### PR DESCRIPTION
Vulkan has extensions that require other extensions to be enabled to be used, which can lead to the following case.

![image](https://github.com/charles-lunarg/vk-bootstrap/assets/32776854/8b24fb07-6aba-4355-bd19-1d06c7262a94)

I propose a cleaner solution that can test a vector of extensions and enables all of them if they're all present.

![image2](https://github.com/charles-lunarg/vk-bootstrap/assets/32776854/63e1ea60-aef6-4ce0-8fde-db18ddf16b6c)

