### PR TITLE
Fix: dangling reference in the range-based for loop

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -130,7 +130,7 @@ template <typename T> class Result {
 	const T&  value () const&    noexcept { assert (m_init); return m_value; }
 	T&        value () &         noexcept { assert (m_init); return m_value; }
 	const T&& value () const&&   noexcept { assert (m_init); return std::move (m_value); }
-	T&&       value () &&        noexcept { assert (m_init); return std::move (m_value); }
+	T         value () &&        noexcept { assert (m_init); return std::move (m_value); }
 
     // std::error_code associated with the error
     std::error_code error() const { assert (!m_init); return m_error.type; }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -126,10 +126,9 @@ template <typename T> class Result {
 	T*       operator-> ()       noexcept { assert (m_init); return &m_value; }
 	const T& operator* () const& noexcept { assert (m_init);	return m_value; }
 	T&       operator* () &      noexcept { assert (m_init); return m_value; }
-	T&&      operator* () &&	 noexcept { assert (m_init); return std::move (m_value); }
+	T        operator* () &&	 noexcept { assert (m_init); return std::move (m_value); }
 	const T&  value () const&    noexcept { assert (m_init); return m_value; }
 	T&        value () &         noexcept { assert (m_init); return m_value; }
-	const T&& value () const&&   noexcept { assert (m_init); return std::move (m_value); }
 	T         value () &&        noexcept { assert (m_init); return std::move (m_value); }
 
     // std::error_code associated with the error


### PR DESCRIPTION
A dangling reference will apear in the following code:

`
for(auto view : vkb_swapchain.get_image_views().value())
{
      //Anything
}
`

Returning an rvalue reference binding the subobject of a tempory object doesn't make any sense.
Please see [this](https://stackoverflow.com/questions/27368236/return-value-or-rvalue-reference) for more details.
There is a simple example: [https://godbolt.org/z/YcEefWGr7](https://godbolt.org/z/YcEefWGr7)