### PR TITLE
Improve function std::vector arguments, add C++20 std::span support

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -768,12 +768,6 @@ InstanceBuilder& InstanceBuilder::enable_extension(const char* extension_name) {
     info.extensions.push_back(extension_name);
     return *this;
 }
-InstanceBuilder& InstanceBuilder::enable_extensions(std::vector<const char*> const& extensions) {
-    for (const auto extension : extensions) {
-        info.extensions.push_back(extension);
-    }
-    return *this;
-}
 InstanceBuilder& InstanceBuilder::enable_extensions(size_t count, const char* const* extensions) {
     if (!extensions || count == 0) return *this;
     for (size_t i = 0; i < count; i++) {
@@ -1038,7 +1032,7 @@ PhysicalDevice PhysicalDeviceSelector::populate_device_details(VkPhysicalDevice 
         } else {
             detail::vulkan_functions().fp_vkGetPhysicalDeviceFeatures2KHR(vk_phys_device, &local_features);
         }
-        physical_device.extended_features_chain = fill_chain;
+        physical_device.extended_features_chain = std::move(fill_chain);
     }
 
     return physical_device;
@@ -1299,12 +1293,6 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extension(const cha
     criteria.required_extensions.push_back(extension);
     return *this;
 }
-PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extensions(std::vector<const char*> const& extensions) {
-    for (const auto& ext : extensions) {
-        criteria.required_extensions.push_back(ext);
-    }
-    return *this;
-}
 PhysicalDeviceSelector& PhysicalDeviceSelector::add_required_extensions(size_t count, const char* const* extensions) {
     if (!extensions || count == 0) return *this;
     for (size_t i = 0; i < count; i++) {
@@ -1399,15 +1387,16 @@ bool PhysicalDevice::enable_extension_if_present(const char* extension) {
     }
     return false;
 }
-bool PhysicalDevice::enable_extensions_if_present(const std::vector<const char*>& extensions) { 
-    for (const auto extension : extensions) {
+bool PhysicalDevice::enable_extensions_if_present(size_t count, const char* const* extensions) {
+    for (size_t i = 0; i < count; ++i) {
+        const auto extension = extensions[i];
         auto it = std::find_if(std::begin(available_extensions),
             std::end(available_extensions),
             [extension](std::string const& ext_name) { return ext_name == extension; });
         if (it == std::end(available_extensions)) return false;
     }
-    for (const auto extension : extensions)
-        extensions_to_enable.push_back(extension);
+    for (size_t i = 0; i < count; ++i)
+        extensions_to_enable.push_back(extensions[i]);
     return true;
 }
 
@@ -1478,9 +1467,6 @@ DispatchTable Device::make_table() const { return { device, fp_vkGetDeviceProcAd
 // ---- Device ---- //
 
 Device::operator VkDevice() const { return this->device; }
-
-CustomQueueDescription::CustomQueueDescription(uint32_t index, std::vector<float> priorities)
-: index(index), priorities(std::move(priorities)) {}
 
 void destroy_device(Device const& device) {
     device.internal_table.fp_vkDestroyDevice(device.device, device.allocation_callbacks);
@@ -1583,10 +1569,6 @@ Result<Device> DeviceBuilder::build() const {
     detail::vulkan_functions().get_device_proc_addr(device.device, device.internal_table.fp_vkDestroyDevice, "vkDestroyDevice");
     device.instance_version = physical_device.instance_version;
     return device;
-}
-DeviceBuilder& DeviceBuilder::custom_queue_setup(std::vector<CustomQueueDescription> queue_descriptions) {
-    info.queue_descriptions = std::move(queue_descriptions);
-    return *this;
 }
 DeviceBuilder& DeviceBuilder::set_allocation_callbacks(VkAllocationCallbacks* callbacks) {
     info.allocation_callbacks = callbacks;
@@ -1938,9 +1920,9 @@ Result<std::vector<VkImageView>> Swapchain::get_image_views(const void* pNext) {
     }
     return views;
 }
-void Swapchain::destroy_image_views(std::vector<VkImageView> const& image_views) {
-    for (auto& image_view : image_views) {
-        internal_table.fp_vkDestroyImageView(device, image_view, allocation_callbacks);
+void Swapchain::destroy_image_views(size_t count, VkImageView const* image_views) {
+    for (size_t i = 0; i < count; ++i) {
+        internal_table.fp_vkDestroyImageView(device, image_views[i], allocation_callbacks);
     }
 }
 Swapchain::operator VkSwapchainKHR() const { return this->swapchain; }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -20,6 +20,16 @@
 #include <cstdio>
 #include <cstring>
 
+#if __cplusplus >= 202002L
+#define VKB_SPAN_OVERLOADS 1
+#elif !defined(VKB_SPAN_OVERLOADS)
+#define VKB_SPAN_OVERLOADS 0
+#endif
+
+#if VKB_SPAN_OVERLOADS
+#include <span>
+#endif
+
 #include <vector>
 #include <string>
 #include <system_error>
@@ -376,8 +386,21 @@ class InstanceBuilder {
     InstanceBuilder& enable_layer(const char* layer_name);
     // Adds an extension to be enabled. Will fail to create an instance if the extension isn't available.
     InstanceBuilder& enable_extension(const char* extension_name);
-    InstanceBuilder& enable_extensions(std::vector<const char*> const& extensions);
+
+    // Add extensions to be enabled. Will fail to create an instance if the extension aren't available.
     InstanceBuilder& enable_extensions(size_t count, const char* const* extensions);
+
+    // Add extensions to be enabled. Will fail to create an instance if the extension aren't available.
+    InstanceBuilder& enable_extensions(std::vector<const char*> const& extensions) {
+        return enable_extensions(extensions.size(), extensions.data());
+    }
+
+#if VKB_SPAN_OVERLOADS
+    // Add extensions to be enabled. Will fail to create an instance if the extension aren't available.
+    InstanceBuilder& enable_extensions(std::span<const char*> extensions) {
+        return enable_extensions(extensions.size(), extensions.data());
+    }
+#endif
 
     // Headless Mode does not load the required extensions for presentation. Defaults to true.
     InstanceBuilder& set_headless(bool headless = true);
@@ -510,7 +533,16 @@ struct PhysicalDevice {
 
     // If all the given extensions are present, make all the extensions be enabled on the device.
     // Returns true if all the extensions are present.
-    bool enable_extensions_if_present(const std::vector<const char*>& extensions);
+    bool enable_extensions_if_present(size_t count, const char* const* extensions);
+    bool enable_extensions_if_present(const std::vector<const char*>& extensions) {
+        return enable_extensions_if_present(extensions.size(), extensions.data());
+    }
+
+#if VKB_SPAN_OVERLOADS
+    bool enable_extensions_if_present(std::span<const char*> extensions) {
+        return enable_extensions_if_present(extensions.size(), extensions.data());
+    }
+#endif
 
     // A conversion function which allows this PhysicalDevice to be used
     // in places where VkPhysicalDevice would have been used.
@@ -595,8 +627,17 @@ class PhysicalDeviceSelector {
     // Require a physical device which supports a specific extension.
     PhysicalDeviceSelector& add_required_extension(const char* extension);
     // Require a physical device which supports a set of extensions.
-    PhysicalDeviceSelector& add_required_extensions(std::vector<const char*> const& extensions);
     PhysicalDeviceSelector& add_required_extensions(size_t count, const char* const* extensions);
+    PhysicalDeviceSelector& add_required_extensions(std::vector<const char*> const& extensions) {
+        return add_required_extensions(extensions.size(), extensions.data());
+    }
+
+#if VKB_SPAN_OVERLOADS
+    // Require a physical device which supports a set of extensions.
+    PhysicalDeviceSelector& add_required_extensions(std::span<const char*> extensions) {
+        return add_required_extensions(extensions.size(), extensions.data());
+    }
+#endif
 
     // Prefer a physical device which supports a specific extension.
     [[deprecated("Use vkb::PhysicalDevice::enable_extension_if_present instead")]] PhysicalDeviceSelector&
@@ -741,8 +782,21 @@ struct Device {
 
 // For advanced device queue setup
 struct CustomQueueDescription {
-    explicit CustomQueueDescription(uint32_t index, std::vector<float> priorities);
-    uint32_t index = 0;
+    explicit CustomQueueDescription(uint32_t index, std::vector<float> const& priorities)
+    : index(index), priorities(priorities) {}
+
+    explicit CustomQueueDescription(uint32_t index, std::vector<float>&& priorities)
+    : index(index), priorities(std::move(priorities)) {}
+
+    explicit CustomQueueDescription(uint32_t index, size_t count, float const* priorities)
+    : index(index), priorities(priorities, priorities + count) {}
+
+#if VKB_SPAN_OVERLOADS
+    explicit CustomQueueDescription(uint32_t index, std::span<const float> priorities)
+    : index(index), priorities(priorities.begin(), priorities.end()) {}
+#endif
+
+    uint32_t index;
     std::vector<float> priorities;
 };
 
@@ -757,7 +811,31 @@ class DeviceBuilder {
 
     // For Advanced Users: specify the exact list of VkDeviceQueueCreateInfo's needed for the application.
     // If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
-    DeviceBuilder& custom_queue_setup(std::vector<CustomQueueDescription> queue_descriptions);
+    DeviceBuilder& custom_queue_setup(size_t count, CustomQueueDescription const* queue_descriptions) {
+        info.queue_descriptions.assign(queue_descriptions, queue_descriptions + count);
+        return *this;
+    }
+    // For Advanced Users: specify the exact list of VkDeviceQueueCreateInfo's needed for the application.
+    // If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
+    DeviceBuilder& custom_queue_setup(std::vector<CustomQueueDescription> const& queue_descriptions) {
+        info.queue_descriptions = queue_descriptions;
+        return *this;
+    }
+    // For Advanced Users: specify the exact list of VkDeviceQueueCreateInfo's needed for the application.
+    // If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
+    DeviceBuilder& custom_queue_setup(std::vector<CustomQueueDescription>&& queue_descriptions) {
+        info.queue_descriptions = std::move(queue_descriptions);
+        return *this;
+    }
+
+#if VKB_SPAN_OVERLOADS
+    // For Advanced Users: specify the exact list of VkDeviceQueueCreateInfo's needed for the application.
+    // If a custom queue setup is provided, getting the queues and queue indexes is up to the application.
+    DeviceBuilder& custom_queue_setup(std::span<const CustomQueueDescription> queue_descriptions) {
+        info.queue_descriptions.assign(queue_descriptions.begin(), queue_descriptions.end());
+        return *this;
+    }
+#endif
 
     // Add a structure to the pNext chain of VkDeviceCreateInfo.
     // The structure must be valid when DeviceBuilder::build() is called.
@@ -802,7 +880,16 @@ struct Swapchain {
     // structure.
     Result<std::vector<VkImageView>> get_image_views();
     Result<std::vector<VkImageView>> get_image_views(const void* pNext);
-    void destroy_image_views(std::vector<VkImageView> const& image_views);
+    void destroy_image_views(size_t count, VkImageView const* image_views);
+    void destroy_image_views(std::vector<VkImageView> const& image_views) {
+        destroy_image_views(image_views.size(), image_views.data());
+    }
+
+#if VKB_SPAN_OVERLOADS
+    void destroy_image_views(std::span<const VkImageView> image_views) {
+        destroy_image_views(image_views.size(), image_views.data());
+    }
+#endif
 
     // A conversion function which allows this Swapchain to be used
     // in places where VkSwapchainKHR would have been used.


### PR DESCRIPTION
While looking at the code, I've noticed that a lot of functions return a plain `std::vector` not behind a reference, that creates extra copying that could be avoided. I've also moved some code from the cpp file to the header file (like the `CustomQueueDescription` constructor) so that the compiler can inline the code. I think the whole of vk-bootstrap could benefit from that. I should make a separate issue about this.

Also I'm not super sure about the formatting, I did format it with clang-format, but stuff like pointer alignment wasn't changed.