### PR TITLE
Set the sType for users to fix regression

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -973,7 +973,7 @@ bool supports_features(const VkPhysicalDeviceFeatures& supported,
 					   const VkPhysicalDeviceFeatures& requested,
 					   const GenericFeatureChain& extension_supported,
 					   const GenericFeatureChain& extension_requested) {
-    
+
 	if (requested.robustBufferAccess && !supported.robustBufferAccess) return false;
 	if (requested.fullDrawIndexUint32 && !supported.fullDrawIndexUint32) return false;
 	if (requested.imageCubeArray && !supported.imageCubeArray) return false;
@@ -1029,7 +1029,7 @@ bool supports_features(const VkPhysicalDeviceFeatures& supported,
 	if (requested.sparseResidencyAliased && !supported.sparseResidencyAliased) return false;
 	if (requested.variableMultisampleRate && !supported.variableMultisampleRate) return false;
 	if (requested.inheritedQueries && !supported.inheritedQueries) return false;
-    
+
 
 	return extension_supported.match(extension_requested);
 }
@@ -1427,20 +1427,20 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features(VkPhysical
 }
 #if defined(VKB_VK_API_VERSION_1_2)
 // Just calls add_required_features
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11) {
-    assert(features_11.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES);
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11) {
+    features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     add_required_extension_features(features_11);
     return *this;
 }
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12) {
-    assert(features_12.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12) {
+    features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
     add_required_extension_features(features_12);
     return *this;
 }
 #endif
 #if defined(VKB_VK_API_VERSION_1_3)
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_13(VkPhysicalDeviceVulkan13Features const& features_13) {
-    assert(features_13.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES);
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_13(VkPhysicalDeviceVulkan13Features& features_13) {
+    features_13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
     add_required_extension_features(features_13);
     return *this;
 }

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -664,15 +664,15 @@ class PhysicalDeviceSelector {
 #if defined(VKB_VK_API_VERSION_1_2)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
     // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
-    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11);
+    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11);
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
     // Must have vulkan version 1.2
-    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12);
+    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12);
 #endif
 #if defined(VKB_VK_API_VERSION_1_3)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan13Features.
     // Must have vulkan version 1.3
-    PhysicalDeviceSelector& set_required_features_13(VkPhysicalDeviceVulkan13Features const& features_13);
+    PhysicalDeviceSelector& set_required_features_13(VkPhysicalDeviceVulkan13Features& features_13);
 #endif
 
     // Used when surface creation happens after physical device selection.

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -656,7 +656,7 @@ TEST_CASE("Adding Optional Extension Features", "[VkBootstrap.enable_features_if
     mock.physical_devices_details[0].add_features_pNext_struct(vulkan_11_features);
 
     auto vulkan_12_features = VkPhysicalDeviceVulkan12Features{};
-    vulkan_12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    // Forget to set this sType - let vk-bootstrap deal with it
     vulkan_12_features.bufferDeviceAddress = true;
     mock.physical_devices_details[0].add_features_pNext_struct(vulkan_12_features);
 


### PR DESCRIPTION
Features 11, 12, and 13 structs used to set the sType manually for the user. That was turned into an assert which inadvertently broke users code. This is being reverted.