### PR TITLE
Make PhysicalDeviceSelector::set_require_featurs_1_X const

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1440,22 +1440,27 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features(VkPhysical
     return *this;
 }
 #if defined(VKB_VK_API_VERSION_1_2)
-// Just calls add_required_features
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11) {
-    features_11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
-    add_required_extension_features(features_11);
+// The implementation of the set_required_features_1X functions sets the sType manually. This was a poor choice since
+// users of Vulkan should expect to fill out their structs properly. To make the functions take the struct parameter by
+// const reference, a local copy must be made in order to set the sType.
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11) {
+    VkPhysicalDeviceVulkan11Features features_11_copy = features_11;
+    features_11_copy.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+    add_required_extension_features(features_11_copy);
     return *this;
 }
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12) {
-    features_12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-    add_required_extension_features(features_12);
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12) {
+    VkPhysicalDeviceVulkan12Features features_12_copy = features_12;
+    features_12_copy.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    add_required_extension_features(features_12_copy);
     return *this;
 }
 #endif
 #if defined(VKB_VK_API_VERSION_1_3)
-PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_13(VkPhysicalDeviceVulkan13Features& features_13) {
-    features_13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
-    add_required_extension_features(features_13);
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_required_features_13(VkPhysicalDeviceVulkan13Features const& features_13) {
+    VkPhysicalDeviceVulkan13Features features_13_copy = features_13;
+    features_13_copy.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+    add_required_extension_features(features_13_copy);
     return *this;
 }
 #endif

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -671,15 +671,15 @@ class PhysicalDeviceSelector {
 #if defined(VKB_VK_API_VERSION_1_2)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan11Features.
     // Must have vulkan version 1.2 - This is due to the VkPhysicalDeviceVulkan11Features struct being added in 1.2, not 1.1
-    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features& features_11);
+    PhysicalDeviceSelector& set_required_features_11(VkPhysicalDeviceVulkan11Features const& features_11);
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan12Features.
     // Must have vulkan version 1.2
-    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features& features_12);
+    PhysicalDeviceSelector& set_required_features_12(VkPhysicalDeviceVulkan12Features const& features_12);
 #endif
 #if defined(VKB_VK_API_VERSION_1_3)
     // Require a physical device which supports the features in VkPhysicalDeviceVulkan13Features.
     // Must have vulkan version 1.3
-    PhysicalDeviceSelector& set_required_features_13(VkPhysicalDeviceVulkan13Features& features_13);
+    PhysicalDeviceSelector& set_required_features_13(VkPhysicalDeviceVulkan13Features const& features_13);
 #endif
 
     // Used when surface creation happens after physical device selection.


### PR DESCRIPTION
Make the API take the struct by const reference by creating a local variable that copies the struct, allowing the sType to be set correctly.

The need to set the sType is due to a deficiency in the first version of these functions, which allows users to not set the sType. Making users set the sType is difficult because it breaks user code without warning upon updating the version of vk-bootstrap used.