### PR TITLE
Don't run ci twice on PR's

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -18,12 +18,13 @@
 
 name: CI Build
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
     linux:
         name: Linux
         runs-on: ubuntu-latest
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         strategy:
             fail-fast: false
             matrix:
@@ -64,7 +65,7 @@ jobs:
     windows:
         name: Windows
         runs-on: windows-latest
-
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         strategy:
             matrix:
                 arch: [ Win32, x64 ]


### PR DESCRIPTION
Prevents ci from being run on branches that have a PR created for them. This doesn't prevent ci from running on PR's from forks.