### PR TITLE
Make double size check more valid

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -61,7 +61,7 @@ bool GenericFeatureChain::match_all(GenericFeatureChain const& extension_request
         return false;
     }
 
-    for (size_t i = 0; i < nodes.size() && i < nodes.size(); ++i) {
+    for (size_t i = 0; i < extension_requested.nodes.size() && i < nodes.size(); ++i) {
         if (!GenericFeaturesPNextNode::match(extension_requested.nodes[i], nodes[i])) return false;
     }
     return true;


### PR DESCRIPTION
It would technically be faster if we just did one of these checks but it seems like there was intent to do some kind of zip(). (referring to python's zip function)

In case someone in the future changes the above if-statement to be a `<` rather than a `!=` then this will be safer.