### PR TITLE
Use UINT32_MAX instead of 65536 for QUEUE_INDEX_MAX_VALUE

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -742,7 +742,7 @@ enum class QueueType { present, graphics, compute, transfer };
 
 namespace detail {
 // Sentinel value, used in implementation only
-inline const uint32_t QUEUE_INDEX_MAX_VALUE = 65536;
+inline const uint32_t QUEUE_INDEX_MAX_VALUE = UINT32_MAX;
 } // namespace detail
 
 // ---- Device ---- //


### PR DESCRIPTION
The sentinel value `QUEUE_INDEX_MAX_VALUE` has been introduced in this https://github.com/charles-lunarg/vk-bootstrap/commit/41203627624b3c21c6cc3e134a73927a17b025f0 commit. Its value 65536 looks confusing to me because the maximum value of `uint32_t` is 4294967295. And I suggest to use an already used in `VkBootstrap.cpp` macro `UINT32_MAX` instead of a magic number 4294967295.