### PR TITLE
Move README example to basic_usage.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,58 +21,41 @@ Read the [Getting Started](docs/getting_started.md) guide for a quick start on u
 
 ## Basic Usage
 
-```cpp
+See [basic_usage.cpp](./example/basic_usage.cpp) to see 500 lines slimmed down to about 50
 
+```cpp
 #include "VkBootstrap.h"
 
-bool init_vulkan () {
+void init_vulkan () {
     vkb::InstanceBuilder builder;
     auto inst_ret = builder.set_app_name ("Example Vulkan Application")
                         .request_validation_layers ()
                         .use_default_debug_messenger ()
                         .build ();
-    if (!inst_ret) {
-        std::cerr << "Failed to create Vulkan instance. Error: " << inst_ret.error().message() << "\n";
-        return false;
-    }
+    if (!inst_ret) { /* report */ }
     vkb::Instance vkb_inst = inst_ret.value ();
 
     vkb::PhysicalDeviceSelector selector{ vkb_inst };
-    auto phys_ret = selector.set_surface (/* from user created window*/)
-                        .set_minimum_version (1, 1) // require a vulkan 1.1 capable device
+    auto phys_ret = selector.set_surface (surface)
+                        .set_minimum_version (1, 1)
                         .require_dedicated_transfer_queue ()
                         .select ();
-    if (!phys_ret) {
-        std::cerr << "Failed to select Vulkan Physical Device. Error: " << phys_ret.error().message() << "\n";
-        return false;
-    }
+    if (!phys_ret) { /* report */ }
 
     vkb::DeviceBuilder device_builder{ phys_ret.value () };
-    // automatically propagate needed data from instance & physical device
     auto dev_ret = device_builder.build ();
-    if (!dev_ret) {
-        std::cerr << "Failed to create Vulkan device. Error: " << dev_ret.error().message() << "\n";
-        return false;
-    }
+    if (!dev_ret) { /* report */ }
     vkb::Device vkb_device = dev_ret.value ();
 
-    // Get the VkDevice handle used in the rest of a vulkan application
-    VkDevice device = vkb_device.device;
-
-    // Get the graphics queue with a helper function
     auto graphics_queue_ret = vkb_device.get_queue (vkb::QueueType::graphics);
-    if (!graphics_queue_ret) {
-        std::cerr << "Failed to get graphics queue. Error: " << graphics_queue_ret.error().message() << "\n";
-        return false;
-    }
+    if (!graphics_queue_ret)  { /* report */ }
     VkQueue graphics_queue = graphics_queue_ret.value ();
-
-    // Turned 400-500 lines of boilerplate into less than fifty.
-    return true;
 }
 ```
 
-See `example/triangle.cpp` for an example that renders a triangle to the screen.
+### More fun quick examples
+
+- [triangle.cpp](./example/triangle.cpp) - renders a triangle to the screen.
 
 ## Setting up `vk-bootstrap`
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,11 +1,18 @@
-add_executable(vk-bootstrap-triangle triangle.cpp)
-target_link_libraries(vk-bootstrap-triangle
-    PRIVATE
-        glfw
-        vk-bootstrap
-        vk-bootstrap-compiler-warnings
-        Vulkan::Headers)
-target_include_directories(vk-bootstrap-triangle PRIVATE ${CMAKE_CURRENT_BINARY_DIR}) # path to build directory for shaders
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+function(add_vulkan_example name)
+    add_executable(vk-bootstrap-${name} ${name}.cpp)
+    target_link_libraries(vk-bootstrap-${name}
+        PRIVATE
+            glfw
+            vk-bootstrap
+            vk-bootstrap-compiler-warnings
+            Vulkan::Headers)
+    target_include_directories(vk-bootstrap-${name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}) # path to build directory for shaders
+endfunction()
+
+add_vulkan_example(triangle)
+add_vulkan_example(basic_usage)
 
 find_program(GLSLANG_FOUND glslang)
 if(GLSLANG_FOUND)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 function(add_vulkan_example name)
     add_executable(vk-bootstrap-${name} ${name}.cpp)
     target_link_libraries(vk-bootstrap-${name}

--- a/example/basic_usage.cpp
+++ b/example/basic_usage.cpp
@@ -1,0 +1,82 @@
+#include <VkBootstrap.h>
+#include <GLFW/glfw3.h>
+#include <iostream>
+#include <vulkan/vulkan_core.h>
+
+bool init_vulkan() {
+    vkb::InstanceBuilder builder;
+    auto inst_ret = builder.set_app_name("Example Vulkan Application")
+                        .request_validation_layers()
+                        .use_default_debug_messenger()
+                        .build();
+    if (!inst_ret) {
+        std::cerr << "Failed to create Vulkan instance. Error: " << inst_ret.error().message() << "\n";
+        return false;
+    }
+    vkb::Instance vkb_inst = inst_ret.value();
+
+    glfwInit();
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    GLFWwindow* window = glfwCreateWindow(1024, 1024, "Vulkan Triangle", NULL, NULL);
+
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (VkResult err = glfwCreateWindowSurface(vkb_inst, window, nullptr, &surface)) {
+        std::cerr << "Failed to select create windows surface\n";
+        return false;
+    }
+
+    vkb::PhysicalDeviceSelector selector{ vkb_inst };
+    auto phys_ret = selector.set_surface(surface).select();
+    if (!phys_ret) {
+        std::cerr << "Failed to select Vulkan Physical Device. Error: " << phys_ret.error().message() << "\n";
+        return false;
+    }
+
+    vkb::DeviceBuilder device_builder{ phys_ret.value() };
+    // automatically propagate needed data from instance & physical device
+    auto dev_ret = device_builder.build();
+    if (!dev_ret) {
+        std::cerr << "Failed to create Vulkan device. Error: " << dev_ret.error().message() << "\n";
+        return false;
+    }
+    vkb::Device vkb_device = dev_ret.value();
+
+    // Get the VkDevice handle used in the rest of a vulkan application
+    VkDevice device = vkb_device.device;
+
+    // Get the graphics queue with a helper function
+    auto graphics_queue_ret = vkb_device.get_queue(vkb::QueueType::graphics);
+    if (!graphics_queue_ret) {
+        std::cerr << "Failed to get graphics queue. Error: " << graphics_queue_ret.error().message() << "\n";
+        return false;
+    }
+    VkQueue graphics_queue = graphics_queue_ret.value();
+
+    vkb::SwapchainBuilder swapchain_builder{ vkb_device };
+    auto swap_ret = swapchain_builder.build();
+    if (!swap_ret) {
+        std::cout << swap_ret.error().message() << "\n";
+        return false;
+    }
+    vkb::Swapchain vkb_swapchain = swap_ret.value();
+
+    // We did it!
+    // Turned 400-500 lines of boilerplate into a fraction of that.
+
+    // Time to cleanup
+    vkb::destroy_swapchain(vkb_swapchain);
+    vkb::destroy_device(vkb_device);
+    vkb::destroy_surface(vkb_inst, surface);
+    vkb::destroy_instance(vkb_inst);
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    (void)device; // silence unused warning
+    (void)graphics_queue;
+    return true;
+}
+
+int main() {
+    if (init_vulkan()) {
+        std::cout << "Boilerplate done, time to write you application!\n";
+    }
+}


### PR DESCRIPTION
1. Reduce the `README.md` example to be simpler (and show how simple it is)
2. Move the comments and actual "basic usage" details to a `basic_usage.cpp` file