### PR TITLE
Use display extension on DIRECT2DISPLAY

### DIFF
--- a/tests/vulkan_mock_setup.cpp
+++ b/tests/vulkan_mock_setup.cpp
@@ -27,7 +27,7 @@ VulkanMock& get_and_setup_default() {
 #elif defined(__ANDROID__)
     mock.instance_extensions.push_back(get_extension_properties("VK_KHR_android_surface"));
 #elif defined(_DIRECT2DISPLAY)
-    mock.instance_extensions.push_back(get_extension_properties("VK_KHR_android_surface"));
+    mock.instance_extensions.push_back(get_extension_properties("VK_KHR_display"));
 #elif defined(__linux__) || defined(__FreeBSD__)
     mock.instance_extensions.push_back(get_extension_properties("VK_KHR_xcb_surface"));
     mock.instance_extensions.push_back(get_extension_properties("VK_KHR_xlib_surface"));


### PR DESCRIPTION
_DIRECT2DISPLAY path probably is not fully supported yet, but this resolves an invalid `VK_KHR_android_surface` usage issue for mock test setup.