### PR TITLE
Remove deprecated functions

### DIFF
--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -48,7 +48,6 @@ TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
         THEN("Can select physical device with customized requirements") {
             vkb::PhysicalDeviceSelector selector(instance);
             auto phys_dev_ret = selector.set_surface(surface)
-                                    .add_desired_extension(VK_KHR_MULTIVIEW_EXTENSION_NAME)
                                     .add_required_extension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME)
                                     .set_minimum_version(1, 0)
                                     .select();


### PR DESCRIPTION
The `desired_<foo>` API functions created ambiguity in what the actual capabilities of a VkInstance and VkDevice were, and thus were deprecated. Since it has been ~2 years from marking them as deprecated, the functions can now be removed.

Note that while the device suitability parameter in physical device selection is removed, the internal logic remains due to the usefulness in moving discrete GPU's to the top of the list and integrated after.