### PR TITLE
Make instance and api versions public in Instance

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -318,6 +318,8 @@ struct Instance {
     VkAllocationCallbacks* allocation_callbacks = nullptr;
     PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr = nullptr;
     PFN_vkGetDeviceProcAddr fp_vkGetDeviceProcAddr = nullptr;
+    uint32_t instance_version = VKB_VK_API_VERSION_1_0;
+    uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
     // A conversion function which allows this Instance to be used
     // in places where VkInstance would have been used.
@@ -329,8 +331,6 @@ struct Instance {
     private:
     bool headless = false;
     bool properties2_ext_enabled = false;
-    uint32_t instance_version = VKB_VK_API_VERSION_1_0;
-    uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
     friend class InstanceBuilder;
     friend class PhysicalDeviceSelector;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -318,7 +318,9 @@ struct Instance {
     VkAllocationCallbacks* allocation_callbacks = nullptr;
     PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr = nullptr;
     PFN_vkGetDeviceProcAddr fp_vkGetDeviceProcAddr = nullptr;
+    // The apiVersion used to create the instance
     uint32_t instance_version = VKB_VK_API_VERSION_1_0;
+    // The instance version queried from vkEnumerateInstanceVersion
     uint32_t api_version = VKB_VK_API_VERSION_1_0;
 
     // A conversion function which allows this Instance to be used


### PR DESCRIPTION
This lets users query this before making a device, which might be needed to make decisions on extensions / features.