### PR TITLE
Update VkBootstrap.h

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -304,9 +304,13 @@ inline VKAPI_ATTR VkBool32 VKAPI_CALL default_debug_callback(VkDebugUtilsMessage
     void*) {
     auto ms = to_string_message_severity(messageSeverity);
     auto mt = to_string_message_type(messageType);
-    printf("[%s: %s]\n%s\n", ms, mt, pCallbackData->pMessage);
+    if (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) {
+        printf("[%s: %s] - %s\n%s\n", ms, mt, pCallbackData->pMessageIdName, pCallbackData->pMessage);
+    } else {
+        printf("[%s: %s]\n%s\n", ms, mt, pCallbackData->pMessage);
+    }
 
-    return VK_FALSE; // Applications must return false here
+    return VK_FALSE; // Applications must return false here (Except Validation, if return true, will skip calling to driver)
 }
 
 class InstanceBuilder;


### PR DESCRIPTION
Improve Callback to handle future 309 SDK Validation error message

new default will look like

```
[WARNING: General]
env var 'VK_INSTANCE_LAYERS' defined and adding layers "VK_LAYER_KHRONOS_validation"
[WARNING: Performance]
vkCreateInstance(): Using debug builds of the validation layers *will* adversely affect performance.
[ERROR: Validation] - VUID-VkShaderModuleCreateInfo-codeSize-01085
vkCreateShaderModule(): pCreateInfo->codeSize must be greater than 0.
The Vulkan spec states: codeSize must be greater than 0 (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-codeSize-01085)
```