### PR TITLE
Eliminate memory leaks inside Result

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -79,6 +79,7 @@ template <typename T> class Result {
             m_error = expected.m_error;
     }
     Result& operator=(Result const& result) noexcept {
+        destroy();
         m_init = result.m_init;
         if (m_init)
             new (&m_value) T{ result.m_value };
@@ -93,6 +94,7 @@ template <typename T> class Result {
             m_error = std::move(expected.m_error);
     }
     Result& operator=(Result&& result) noexcept {
+        destroy();
         m_init = result.m_init;
         if (m_init)
             new (&m_value) T{ std::move(result.m_value) };


### PR DESCRIPTION
Fixes https://github.com/charles-lunarg/vk-bootstrap/issues/356.

`destroy()` calls are needed in `Result& operator=(Result const& result)` and `Result& operator=(Result&& result)` because assignment operators, in contrary to constructors, are called for already constructed objects. Constructed objects may have allocated memory that is needed to be freed by calling `destroy()` before proceeding.

You may observe such approach inside other assignment operators: `Result& operator=(const T& expect)`, `Result& operator=(T&& expect)`, `Result& operator=(const Error& error)`, `Result& operator=(Error&& error)`. They all have `destroy()` call in the beginning.