### PR TITLE
Cleanup Tests & add Address Sanitizer support

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -50,7 +50,7 @@ jobs:
                 sudo apt-get install -y xorg-dev
 
             - name: CMake Configure
-              run: cmake -S. -B build -DCMAKE_BUILD_TYPE=${{matrix.type}} -DVK_BOOTSTRAP_WERROR=ON -DVK_BOOTSTRAP_TEST=ON
+              run: cmake -S. -B build -DCMAKE_BUILD_TYPE=${{matrix.type}} -DVK_BOOTSTRAP_WERROR=ON -DVK_BOOTSTRAP_TEST=ON -DENABLE_ADDRESS_SANITIZER=ON
 
             - name: CMake Build
               run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,15 @@ set_target_properties(vk-bootstrap PROPERTIES POSITION_INDEPENDENT_CODE ${VK_BOO
 
 if(VK_BOOTSTRAP_TEST)
     enable_testing()
+
+    option(ENABLE_ADDRESS_SANITIZER "Use address sanitization")
+    if (ENABLE_ADDRESS_SANITIZER)
+        target_compile_options(vk-bootstrap-compiler-warnings INTERFACE -fsanitize=address)
+        if (NOT MSVC)
+            target_link_options(vk-bootstrap-compiler-warnings INTERFACE -fsanitize=address)
+        endif()
+    endif()
+
     add_subdirectory(ext)
     add_subdirectory(tests)
     add_subdirectory(example)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 target_link_libraries(VulkanMock
     PUBLIC
-        Vulkan::Headers vk-bootstrap Catch2::Catch2
+        Vulkan::Headers Catch2::Catch2
     PRIVATE
         vk-bootstrap-compiler-warnings
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,12 @@
+add_library(VulkanMock SHARED vulkan_mock.hpp vulkan_mock.cpp)
+# Need to set the target name to "vulkan" so that it'll be loaded instead of the *actual* Vulkan Loader on the system
 if (WIN32)
-    add_library(VulkanMock SHARED vulkan_mock.hpp vulkan_mock.cpp)
-    # Need to name the target "vulkan-1" so that it'll be loaded instead of the *actual* vulkan-1.dll on the system
     set_target_properties(VulkanMock PROPERTIES OUTPUT_NAME "vulkan-1")
 else()
-    add_library(VulkanMock STATIC vulkan_mock.hpp vulkan_mock.cpp)
+    set_target_properties(VulkanMock PROPERTIES OUTPUT_NAME "vulkan")
 endif()
+set_target_properties(VulkanMock PROPERTIES SOVERSION 1)
+
 target_link_libraries(VulkanMock
     PUBLIC
         Vulkan::Headers Catch2::Catch2

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -210,7 +210,8 @@ TEST_CASE("Select all Physical Devices", "[VkBootstrap.bootstrap]") {
     VulkanMock& mock = get_and_setup_default();
     mock.api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
-    std::copy_n("mocking_gpus_for_fun_and_profit", VK_MAX_DRIVER_NAME_SIZE, mock.physical_devices_details[0].properties.deviceName);
+    const char* message = "mocking_gpus_for_fun_and_profit";
+    std::copy_n(message, sizeof(message) + 1, mock.physical_devices_details[0].properties.deviceName);
 
     auto instance = get_instance(1);
     auto surface = mock.get_new_surface(get_basic_surface_details());

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -710,7 +710,7 @@ TEST_CASE("Adding Optional Extension Features", "[VkBootstrap.enable_features_if
                 REQUIRE(!phys_dev.enable_extension_features_if_present(phys_dev_vulkan_11_features));
                 auto device = vkb::DeviceBuilder(phys_dev).build().value();
                 auto* s = reinterpret_cast<VkPhysicalDeviceVulkan12Features*>(
-                    &mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0));
+                    mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0).data());
                 REQUIRE(s->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES);
                 vkb::destroy_device(device);
             }
@@ -722,7 +722,7 @@ TEST_CASE("Adding Optional Extension Features", "[VkBootstrap.enable_features_if
                 REQUIRE(phys_dev.enable_extension_features_if_present(phys_dev_vulkan_11_features));
                 auto device = vkb::DeviceBuilder(phys_dev).build().value();
                 auto* s = reinterpret_cast<VkPhysicalDeviceVulkan11Features*>(
-                    &mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(1));
+                    mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(1).data());
                 REQUIRE(s->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES);
                 REQUIRE(s->shaderDrawParameters);
                 vkb::destroy_device(device);
@@ -884,10 +884,10 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
             auto device_ret = device_builder.build();
             REQUIRE(device_ret.has_value());
             auto* s1 = reinterpret_cast<VkPhysicalDeviceVulkan11Features*>(
-                &mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0));
+                mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0).data());
             REQUIRE(s1->multiview);
             auto* s2 = reinterpret_cast<VkPhysicalDeviceVulkan12Features*>(
-                &mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(1));
+                mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(1).data());
             REQUIRE(s2->bufferDeviceAddress);
 
             vkb::destroy_device(device_ret.value());
@@ -969,7 +969,7 @@ TEST_CASE("Add required extension features in multiple calls", "[VkBootstrap.req
             auto device_ret = device_builder.build();
             REQUIRE(device_ret.has_value());
             auto* s1 = reinterpret_cast<VkPhysicalDeviceVulkan11Features*>(
-                &mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0));
+                mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain.at(0).data());
             REQUIRE(s1->multiview);
             REQUIRE(s1->samplerYcbcrConversion);
 

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -978,3 +978,53 @@ TEST_CASE("Add required extension features in multiple calls", "[VkBootstrap.req
         vkb::destroy_instance(instance);
     }
 }
+
+// Simple Rule of 3 type
+class Sample {
+    public:
+    Sample() { data = new int; }
+    Sample(Sample const& sample) {
+        data = new int;
+        *data = *sample.data;
+    }
+    Sample& operator=(Sample const& sample) {
+
+        *data = *sample.data;
+        return *this;
+    }
+
+    virtual ~Sample() { delete data; }
+
+    private:
+    int* data;
+};
+
+TEST_CASE("Check vkb::Result", "[VkBootstrap.Result]") {
+    {
+        vkb::Result<std::vector<float>> a{ std::vector<float>(30, 3.0f) };
+        auto b = std::move(a);
+        b.value().push_back(5.0f);
+        vkb::Result<std::vector<float>> c{ std::move(b) };
+        c.value().push_back(7.0f);
+        auto d = std::move(c);
+        d.value().push_back(9.0f);
+    }
+    {
+        vkb::Result<std::unique_ptr<float>> a{ std::make_unique<float>(3.0f) };
+        vkb::Result<std::unique_ptr<float>> b{ std::make_unique<float>(3.0f) };
+        b = std::move(a);
+        *b.value().get() = 5.0f;
+        vkb::Result<std::unique_ptr<float>> c{ std::move(b) };
+        *c.value().get() = 7.0f;
+        auto d = std::move(c);
+        *d.value().get() = 9.0f;
+    }
+    {
+
+        vkb::Result<Sample> result(Sample{});
+        vkb::Result<Sample> anotherResult(std::move(result));
+        vkb::Result<Sample> c = result;
+        vkb::Result<Sample> d(Sample{});
+        d = c;
+    }
+}

--- a/tests/vulkan_mock.hpp
+++ b/tests/vulkan_mock.hpp
@@ -10,8 +10,6 @@
 
 #include <vulkan/vulkan_core.h>
 
-#include <VkBootstrap.h>
-
 // Helper function to return the size of the sType if it is a known features struct, otherwise return 0
 // Hand written, must be updated to include any used struct.
 inline size_t check_if_features2_struct(VkStructureType type) {
@@ -77,7 +75,7 @@ struct VulkanMock {
     struct CreatedDeviceDetails {
         VkPhysicalDeviceFeatures features{};
         std::vector<const char*> extensions;
-        std::vector<vkb::detail::GenericFeaturesPNextNode> features_pNextChain;
+        std::vector<std::vector<char>> features_pNextChain;
     };
 
     struct PhysicalDeviceDetails {
@@ -86,12 +84,17 @@ struct VulkanMock {
         VkPhysicalDeviceMemoryProperties memory_properties{};
         std::vector<VkExtensionProperties> extensions;
         std::vector<VkQueueFamilyProperties> queue_family_properties;
-        std::vector<vkb::detail::GenericFeaturesPNextNode> features_pNextChain;
+        std::vector<std::vector<char>> features_pNextChain;
 
         std::vector<VkDevice> created_device_handles;
         std::vector<CreatedDeviceDetails> created_device_details;
 
-        template <typename T> void add_features_pNext_struct(T features) { features_pNextChain.push_back(features); }
+        template <typename T> void add_features_pNext_struct(T features) {
+            std::vector<char> new_struct;
+            new_struct.resize(sizeof(T));
+            memcpy(new_struct.data(), &features, new_struct.size());
+            features_pNextChain.push_back(new_struct);
+        }
     };
 
     std::vector<VkPhysicalDevice> physical_device_handles;

--- a/tests/vulkan_mock_setup.cpp
+++ b/tests/vulkan_mock_setup.cpp
@@ -15,7 +15,7 @@ vkb::Instance get_headless_instance(uint32_t minor_version) {
 
 VkExtensionProperties get_extension_properties(const char* extName) {
     VkExtensionProperties ext_props{};
-    std::copy_n(extName, VK_MAX_EXTENSION_NAME_SIZE, ext_props.extensionName);
+    std::copy_n(extName, strlen(extName) + 1, ext_props.extensionName);
     return ext_props;
 }
 

--- a/tests/vulkan_mock_setup.hpp
+++ b/tests/vulkan_mock_setup.hpp
@@ -6,6 +6,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <VkBootstrap.h>
 
 vkb::Instance get_instance(uint32_t minor_version = 0);
 


### PR DESCRIPTION
* Adds ENABLE_ADDRESS_SANITIZER for testing and enables it in CI
* Fix issues in tests found by ASAN
* Make VulkanMock independent from vk-bootstrap (was only needed for the feature struct pNext chain helper)
* Simplify the linux shim - do not need to intercept dlsym, needed for ASAN
* Add a test case for vkb::Result<> so that it has test coverage.