### PR TITLE
Safely convert return value of GetProcAddress

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -152,7 +152,8 @@ class VulkanFunctions {
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         func_dest = reinterpret_cast<T>(dlsym(library, func_name));
 #elif defined(_WIN32)
-        func_dest = reinterpret_cast<T>(GetProcAddress(library, func_name));
+        // GetProcAddress returns FARPROC, so need to cast it into a void* which can safely be cast to T
+        func_dest = reinterpret_cast<T>(reinterpret_cast<void*>(GetProcAddress(library, func_name)));
 #endif
     }
     void close() {


### PR DESCRIPTION
Window's GetProcAddress returns FARPROC, not void*, so needs extra work to cast into the output type safely.