### PR TITLE
Add support for VK_EXT_layer_settings

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -660,6 +660,10 @@ Result<Instance> InstanceBuilder::build() const {
         extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
 
+    if (info.layer_settings.size() > 0) {
+        extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
+    }
+
 #if defined(VK_KHR_portability_enumeration)
     bool portability_enumeration_support =
         detail::check_extension_supported(system.available_extensions, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
@@ -740,6 +744,15 @@ Result<Instance> InstanceBuilder::build() const {
         checks.disabledValidationCheckCount = static_cast<uint32_t>(info.disabled_validation_checks.size());
         checks.pDisabledValidationChecks = info.disabled_validation_checks.data();
         pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&checks));
+    }
+
+    VkLayerSettingsCreateInfoEXT layer_settings_ci{};
+    if (info.layer_settings.size() > 0) {
+        layer_settings_ci.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT;
+        layer_settings_ci.pNext = nullptr;
+        layer_settings_ci.settingCount = static_cast<uint32_t>(info.layer_settings.size());
+        layer_settings_ci.pSettings = info.layer_settings.data();
+        pNext_chain.push_back(reinterpret_cast<VkBaseOutStructure*>(&layer_settings_ci));
     }
 
     VkInstanceCreateInfo instance_create_info = {};
@@ -914,6 +927,10 @@ InstanceBuilder& InstanceBuilder::add_validation_feature_disable(VkValidationFea
 }
 InstanceBuilder& InstanceBuilder::set_allocation_callbacks(VkAllocationCallbacks* callbacks) {
     info.allocation_callbacks = callbacks;
+    return *this;
+}
+InstanceBuilder& InstanceBuilder::add_layer_setting(VkLayerSettingEXT setting) {
+    info.layer_settings.push_back(setting);
     return *this;
 }
 

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -455,6 +455,9 @@ class InstanceBuilder {
     // Provide custom allocation callbacks.
     InstanceBuilder& set_allocation_callbacks(VkAllocationCallbacks* callbacks);
 
+    // Set a setting on a requested layer via VK_EXT_layer_settings
+    InstanceBuilder& add_layer_setting(VkLayerSettingEXT setting);
+
     private:
     struct InstanceInfo {
         // VkApplicationInfo
@@ -470,6 +473,7 @@ class InstanceBuilder {
         std::vector<const char*> extensions;
         VkInstanceCreateFlags flags = static_cast<VkInstanceCreateFlags>(0);
         std::vector<VkBaseOutStructure*> pNext_elements;
+        std::vector<VkLayerSettingEXT> layer_settings;
 
         // debug callback - use the default so it is not nullptr
         PFN_vkDebugUtilsMessengerCallbackEXT debug_callback = default_debug_callback;

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -1028,3 +1028,29 @@ TEST_CASE("Check vkb::Result", "[VkBootstrap.Result]") {
         d = c;
     }
 }
+
+TEST_CASE("Test VK_EXT_layer_settings", "[VkBoostrap.LayerSettings]") {
+    VulkanMock& mock = get_and_setup_default();
+
+    SECTION("Missing extension") {
+        VkBool32 vkTrue = VK_TRUE;
+        const VkLayerSettingEXT layer_setting = {
+            "VK_LAYER_KHRONOS_validation", "validate_core", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &vkTrue
+        };
+
+        auto ret = vkb::InstanceBuilder{}.set_headless().add_layer_setting(layer_setting).build();
+        REQUIRE(ret.error() == vkb::InstanceError::requested_extensions_not_present);
+    }
+
+    mock.instance_extensions.push_back(get_extension_properties(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME));
+
+    SECTION("Set layer setting") {
+        VkBool32 vkTrue = VK_TRUE;
+        const VkLayerSettingEXT layer_setting = {
+            "VK_LAYER_KHRONOS_validation", "validate_core", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &vkTrue
+        };
+
+        auto ret = vkb::InstanceBuilder{}.set_headless().add_layer_setting(layer_setting).build();
+        REQUIRE(ret);
+    }
+}


### PR DESCRIPTION
Prevously `vkb::InstanceBuilder` had support for changing settings in VVL via the VK_EXT_validation_features and VK_EXT_validation_flags extensions.

Recently, these two extension have been deprecated and replaced with the VK_EXT_layer_settings extension, which also allows for generic support for settings in any enabled layer.

This change adds support for setting layer settings when creating an instance with `vkb::InstanceBuilder` via the VK_EXT_layer_settings extension.