### PR TITLE
Working on tests

### DIFF
--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -594,7 +594,7 @@ TEST_CASE("Querying Required Extension Features but with 1.0", "[VkBootstrap.sel
     auto mock_descriptor_indexing_features = VkPhysicalDeviceDescriptorIndexingFeaturesEXT{};
     mock_descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
     mock_descriptor_indexing_features.runtimeDescriptorArray = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_descriptor_indexing_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_descriptor_indexing_features));
     GIVEN("A working instance") {
         auto instance = get_headless_instance();
         // Requires a device that supports runtime descriptor arrays via descriptor indexing extension.
@@ -626,7 +626,7 @@ TEST_CASE("Querying Required Extension Features", "[VkBootstrap.select_features]
     auto mock_descriptor_indexing_features = VkPhysicalDeviceDescriptorIndexingFeaturesEXT{};
     mock_descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
     mock_descriptor_indexing_features.runtimeDescriptorArray = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_descriptor_indexing_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_descriptor_indexing_features));
     GIVEN("A working instance") {
         auto instance = get_headless_instance();
         // Requires a device that supports runtime descriptor arrays via descriptor indexing extension.
@@ -666,12 +666,12 @@ TEST_CASE("Error from Required Extension Features", "[VkBootstrap.missing_featur
     mock_descriptor_indexing_features_0.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
     mock_descriptor_indexing_features_0.runtimeDescriptorArray = true;
     mock_descriptor_indexing_features_0.descriptorBindingPartiallyBound = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_descriptor_indexing_features_0);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_descriptor_indexing_features_0));
     auto mock_descriptor_indexing_features_1 = VkPhysicalDeviceDescriptorIndexingFeaturesEXT{};
     mock_descriptor_indexing_features_1.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
     mock_descriptor_indexing_features_1.descriptorBindingSampledImageUpdateAfterBind = true;
     mock_descriptor_indexing_features_1.descriptorBindingStorageBufferUpdateAfterBind = true;
-    mock.physical_devices_details[1].add_features_pNext_struct(mock_descriptor_indexing_features_1);
+    mock.physical_devices_details[1].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_descriptor_indexing_features_1));
     GIVEN("A working instance") {
         auto instance = get_headless_instance();
         {
@@ -727,12 +727,12 @@ TEST_CASE("Adding Optional Extension Features", "[VkBootstrap.enable_features_if
     auto vulkan_11_features = VkPhysicalDeviceVulkan11Features{};
     vulkan_11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     vulkan_11_features.shaderDrawParameters = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(vulkan_11_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(vulkan_11_features));
 
     auto vulkan_12_features = VkPhysicalDeviceVulkan12Features{};
     vulkan_12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
     vulkan_12_features.bufferDeviceAddress = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(vulkan_12_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(vulkan_12_features));
 
 
     GIVEN("A working instance and physical device which has a VkPhysicalDeviceVulkan12Features in its features pNext "
@@ -843,7 +843,7 @@ TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]"
     auto mock_descriptor_indexing_features = VkPhysicalDeviceDescriptorIndexingFeaturesEXT{};
     mock_descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
     mock_descriptor_indexing_features.runtimeDescriptorArray = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_descriptor_indexing_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_descriptor_indexing_features));
     GIVEN("A working instance") {
         auto instance = get_headless_instance();
         SECTION("Requires a device that supports runtime descriptor arrays via descriptor indexing extension.") {
@@ -941,12 +941,12 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
     auto mock_vulkan_11_features = VkPhysicalDeviceVulkan11Features{};
     mock_vulkan_11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     mock_vulkan_11_features.multiview = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_vulkan_11_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_vulkan_11_features));
 
     auto mock_vulkan_12_features = VkPhysicalDeviceVulkan12Features{};
     mock_vulkan_12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
     mock_vulkan_12_features.bufferDeviceAddress = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_vulkan_12_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_vulkan_12_features));
 
     GIVEN("A working instance") {
         auto instance = get_headless_instance(2); // make sure we use 1.2
@@ -1030,7 +1030,7 @@ TEST_CASE("Add required extension features in multiple calls", "[VkBootstrap.req
     mock_vulkan_11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     mock_vulkan_11_features.multiview = true;
     mock_vulkan_11_features.samplerYcbcrConversion = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(mock_vulkan_11_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(mock_vulkan_11_features));
 
     GIVEN("A working instance") {
         auto instance = get_headless_instance(1); // make sure we use 1.1

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -448,9 +448,6 @@ TEST_CASE("SystemInfo Loading Vulkan Automatically", "[VkBootstrap.loading]") {
     [[maybe_unused]] VulkanMock& mock = get_and_setup_default();
     auto info_ret = vkb::SystemInfo::get_system_info();
     REQUIRE(info_ret);
-    vkb::InstanceBuilder builder;
-    auto ret = builder.build();
-    REQUIRE(ret);
 }
 
 TEST_CASE("SystemInfo Check Instance API Version", "[VkBootstrap.instance_api_version]") {
@@ -478,9 +475,6 @@ TEST_CASE("SystemInfo Loading Vulkan Manually", "[VkBootstrap.loading]") {
     REQUIRE(vk_lib.vkGetInstanceProcAddr);
     auto info_ret = vkb::SystemInfo::get_system_info(vk_lib.vkGetInstanceProcAddr);
     REQUIRE(info_ret);
-    vkb::InstanceBuilder builder;
-    auto ret = builder.build();
-    REQUIRE(ret);
     vk_lib.close();
 }
 

--- a/tests/vulkan_hpp_tests.cpp
+++ b/tests/vulkan_hpp_tests.cpp
@@ -25,13 +25,13 @@ TEST_CASE("VulkanHpp Instance with surface", "[VkBootstrap.vulkan_hpp]") {
     physical_device_descriptor_indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
     physical_device_descriptor_indexing_features.runtimeDescriptorArray = true;
     physical_device_descriptor_indexing_features.descriptorBindingPartiallyBound = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(physical_device_descriptor_indexing_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(physical_device_descriptor_indexing_features));
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_EXT_subgroup_size_control"));
     VkPhysicalDeviceSubgroupSizeControlFeatures physical_device_subgroup_size_control_features{};
     physical_device_subgroup_size_control_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
     physical_device_subgroup_size_control_features.subgroupSizeControl = true;
     physical_device_subgroup_size_control_features.computeFullSubgroups = true;
-    mock.physical_devices_details[0].add_features_pNext_struct(physical_device_subgroup_size_control_features);
+    mock.physical_devices_details[0].features_pNextChain.emplace_back(create_serialized_struct_from_object(physical_device_subgroup_size_control_features));
 
     auto surface = mock.get_new_surface(get_basic_surface_details());
     vk::SurfaceKHR hpp_surface{ surface };

--- a/tests/vulkan_mock.cpp
+++ b/tests/vulkan_mock.cpp
@@ -2,8 +2,6 @@
 
 #include "vulkan_mock.hpp"
 
-#include <cstring>
-
 #include <algorithm>
 
 #define GPA_IMPL(x)                                                                                                    \
@@ -185,7 +183,7 @@ VKAPI_ATTR VkResult VKAPI_CALL shim_vkCreateDevice(VkPhysicalDevice physicalDevi
     if (pCreateInfo->pEnabledFeatures) {
         new_feats = *pCreateInfo->pEnabledFeatures;
     }
-    std::vector<std::vector<char>> new_chain;
+    std::vector<SerializedStruct> new_chain;
     std::vector<const char*> created_extensions;
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         created_extensions.push_back(pCreateInfo->ppEnabledExtensionNames[i]);
@@ -195,10 +193,7 @@ VKAPI_ATTR VkResult VKAPI_CALL shim_vkCreateDevice(VkPhysicalDevice physicalDevi
         const auto* chain = static_cast<const VkBaseOutStructure*>(pNext_chain);
         const void* next = chain->pNext;
         if (check_if_features2_struct(chain->sType) > 0) {
-            std::vector<char> new_node;
-            new_node.resize(get_pnext_chain_struct_size(chain->sType));
-            std::memcpy(new_node.data(), pNext_chain, new_node.size());
-            new_chain.push_back(new_node);
+            new_chain.emplace_back(create_serialized_struct_from_pointer(pNext_chain, get_pnext_chain_struct_size(chain->sType)));
         }
         if (chain->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2) {
             new_feats = static_cast<const VkPhysicalDeviceFeatures2*>(pNext_chain)->features;


### PR DESCRIPTION
1. I removed the irrelevant code

```
    vkb::InstanceBuilder builder;
    auto ret = builder.build();
    REQUIRE(ret);
```

from 2 tests. For example, gettng the system info in the following test

```
TEST_CASE("SystemInfo Loading Vulkan Automatically", "[VkBootstrap.loading]") {
    [[maybe_unused]] VulkanMock& mock = get_and_setup_default();
    auto info_ret = vkb::SystemInfo::get_system_info();
    REQUIRE(info_ret);
    vkb::InstanceBuilder builder;
    auto ret = builder.build();
    REQUIRE(ret);
}
```

prior to instance building doesn't affect instance building. The instance builder gets the system info internally from scratch anyway:

```
Result<Instance> InstanceBuilder::build() const {

    auto sys_info_ret = SystemInfo::get_system_info(info.fp_vkGetInstanceProcAddr);
```

I supposed that maybe the intention of additional instance building was to obtain `detail::vulkan_functions().ptr_vkGetInstanceProcAddr`, which is set after calling `vkb::SystemInfo::get_system_info()`, and use it for instance building like

```
vkb::InstanceBuilder builder{ detail::vulkan_functions().ptr_vkGetInstanceProcAddr };
```

but the whole `detail::vulkan_functions()` is not exposed to users, hidden inside `src/VkBootstrap.cpp`. So I removed irrelevant instance building happening after testing `SystemInfo`.

2. In an attempt to do something with https://github.com/charles-lunarg/vk-bootstrap/issues/377, I added a test for running in multiple threads the code that is expected to be thread safe. It uses the mentioned line `std::lock_guard<std::mutex> lg(init_mutex);` inside.

3. I attempted to unify the usage of `std::vector<char>`.