### PR TITLE
Handle when minimum_instance_version is set but required_api_version isn't

### DIFF
--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("Instance with surface", "[VkBootstrap.bootstrap]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_multiview"));
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_driver_properties"));
@@ -146,7 +146,7 @@ TEST_CASE("Headless Vulkan", "[VkBootstrap.bootstrap]") {
 
 TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     auto instance = get_instance(1);
     auto surface = mock.get_new_surface(get_basic_surface_details());
@@ -208,7 +208,7 @@ TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
 
 TEST_CASE("Select all Physical Devices", "[VkBootstrap.bootstrap]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     std::string message = "mocking_gpus_for_fun_and_profit";
     std::copy_n(message.c_str(), message.size(), mock.physical_devices_details[0].properties.deviceName);
@@ -270,7 +270,7 @@ TEST_CASE("Loading Dispatch Table", "[VkBootstrap.bootstrap]") {
 
 TEST_CASE("Swapchain", "[VkBootstrap.bootstrap]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     auto surface = mock.get_new_surface(get_basic_surface_details());
     GIVEN("A working instance, window, surface, and device") {
@@ -455,7 +455,7 @@ TEST_CASE("SystemInfo Loading Vulkan Automatically", "[VkBootstrap.loading]") {
 
 TEST_CASE("SystemInfo Check Instance API Version", "[VkBootstrap.instance_api_version]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     auto info_ret = vkb::SystemInfo::get_system_info();
     REQUIRE(info_ret);
     auto system_info = info_ret.value();
@@ -536,7 +536,7 @@ TEST_CASE("ReLoading Vulkan Manually", "[VkBootstrap.loading]") {
 
 TEST_CASE("Minimum instance API version", "[VkBootstrap.api_version]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_3;
     mock.physical_devices_details[0].properties.deviceID = 1;
     add_basic_physical_device(mock).properties.apiVersion = VK_API_VERSION_1_4;
@@ -562,7 +562,7 @@ TEST_CASE("Minimum instance API version", "[VkBootstrap.api_version]") {
 }
 TEST_CASE("Minimum instance API version lower than VkPhysicalDevice", "[VkBootstrap.api_version]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_3;
     mock.physical_devices_details[0].properties.deviceID = 1;
     {
@@ -703,7 +703,7 @@ TEST_CASE("Error from Required Extension Features", "[VkBootstrap.missing_featur
 
 TEST_CASE("Adding Optional Extension Features", "[VkBootstrap.enable_features_if_present]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     mock.instance_extensions.push_back(get_extension_properties("VK_KHR_get_physical_device_properties2"));
     auto vulkan_10_features = VkPhysicalDeviceFeatures{};
@@ -921,7 +921,7 @@ TEST_CASE("Querying Required Extension Features in 1.1", "[VkBootstrap.version]"
 
 TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_2;
 
     auto mock_vulkan_11_features = VkPhysicalDeviceVulkan11Features{};
@@ -960,7 +960,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 
             vkb::destroy_device(device_ret.value());
         }
-        mock.api_version = VK_API_VERSION_1_1;
+        mock.instance_api_version = VK_API_VERSION_1_1;
         mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
         SECTION("protectedMemory should NOT be supported") {
             VkPhysicalDeviceVulkan11Features features_11{};
@@ -977,7 +977,7 @@ TEST_CASE("Querying Vulkan 1.1 and 1.2 features", "[VkBootstrap.version]") {
 
 TEST_CASE("Add required features in multiple calls", "[VkBootstrap.required_features]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].features.independentBlend = true;
     mock.physical_devices_details[0].features.shaderInt64 = true;
@@ -1009,7 +1009,7 @@ TEST_CASE("Add required features in multiple calls", "[VkBootstrap.required_feat
 
 TEST_CASE("Add required extension features in multiple calls", "[VkBootstrap.required_features]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_2;
+    mock.instance_api_version = VK_API_VERSION_1_2;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_2;
 
     auto mock_vulkan_11_features = VkPhysicalDeviceVulkan11Features{};

--- a/tests/vulkan_hpp_tests.cpp
+++ b/tests/vulkan_hpp_tests.cpp
@@ -15,7 +15,7 @@
 
 TEST_CASE("VulkanHpp Instance with surface", "[VkBootstrap.vulkan_hpp]") {
     VulkanMock& mock = get_and_setup_default();
-    mock.api_version = VK_API_VERSION_1_1;
+    mock.instance_api_version = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].properties.apiVersion = VK_API_VERSION_1_1;
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_multiview"));
     mock.physical_devices_details[0].extensions.push_back(get_extension_properties("VK_KHR_driver_properties"));

--- a/tests/vulkan_mock.cpp
+++ b/tests/vulkan_mock.cpp
@@ -50,7 +50,7 @@ VKAPI_ATTR VkResult VKAPI_CALL shim_vkEnumerateInstanceVersion(uint32_t* pApiVer
     if (pApiVersion == nullptr) {
         return VK_ERROR_DEVICE_LOST;
     }
-    *pApiVersion = mock.api_version;
+    *pApiVersion = mock.instance_api_version;
     return VK_SUCCESS;
 }
 
@@ -72,13 +72,16 @@ VKAPI_ATTR VkResult VKAPI_CALL shim_vkEnumerateInstanceLayerProperties(uint32_t*
     return fill_out_count_pointer_pair(mock.instance_layers, pPropertyCount, pProperties);
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL shim_vkCreateInstance([[maybe_unused]] const VkInstanceCreateInfo* pCreateInfo,
-    [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-    VkInstance* pInstance) {
+VKAPI_ATTR VkResult VKAPI_CALL shim_vkCreateInstance(
+    const VkInstanceCreateInfo* pCreateInfo, [[maybe_unused]] const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
     if (pInstance == nullptr) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
     *pInstance = get_handle<VkInstance>(0x0000ABCDU);
+
+    if (pCreateInfo && pCreateInfo->pApplicationInfo) {
+        mock.api_version_set_by_vkCreateInstance = pCreateInfo->pApplicationInfo->apiVersion;
+    }
     return VK_SUCCESS;
 }
 VKAPI_ATTR void VKAPI_CALL shim_vkDestroyInstance(

--- a/tests/vulkan_mock.hpp
+++ b/tests/vulkan_mock.hpp
@@ -43,7 +43,7 @@ template <typename T> T get_uint64_handle(uint64_t value) { return reinterpret_c
 #endif
 
 struct VulkanMock {
-    uint32_t api_version = VK_API_VERSION_1_3;
+    uint32_t instance_api_version = VK_API_VERSION_1_3;
     std::vector<VkExtensionProperties> instance_extensions;
     std::vector<VkLayerProperties> instance_layers;
     std::vector<std::vector<VkExtensionProperties>> per_layer_instance_extension_properties;
@@ -109,6 +109,9 @@ struct VulkanMock {
         physical_device_handles.push_back(get_handle<VkPhysicalDevice>(0x22334455U + physical_device_handles.size()));
         physical_devices_details.emplace_back(std::move(details));
     }
+
+    // Values set by various Vulkan API calls
+    uint32_t api_version_set_by_vkCreateInstance = 0;
 };
 
 extern "C" {


### PR DESCRIPTION
Adds missing logic to handle when set_minimum_instance_version is called but require_api_version isn't. 

Now correctly logs error messages when set_minimum_instance_version results in an instance version error.

Adds tests to check the validity of set_minimum_instance_version.