### PR TITLE
Cleanup image views in error path

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -2038,8 +2038,11 @@ Result<std::vector<VkImageView>> Swapchain::get_image_views(const void* pNext) {
         createInfo.subresourceRange.baseArrayLayer = 0;
         createInfo.subresourceRange.layerCount = 1;
         VkResult res = internal_table.fp_vkCreateImageView(device, &createInfo, allocation_callbacks, &views[i]);
-        if (res != VK_SUCCESS)
+        if (res != VK_SUCCESS) {
+            // Cleanup already created image views
+            destroy_image_views(i, views.data());
             return Result<std::vector<VkImageView>>{ SwapchainError::failed_create_swapchain_image_views, res };
+        }
     }
     return views;
 }

--- a/tests/vulkan_mock.cpp
+++ b/tests/vulkan_mock.cpp
@@ -273,13 +273,24 @@ VKAPI_ATTR VkResult VKAPI_CALL shim_vkCreateImageView([[maybe_unused]] VkDevice 
     [[maybe_unused]] const VkImageViewCreateInfo* pCreateInfo,
     [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
     VkImageView* pView) {
+    if (mock.fail_image_creation_on_iteration != std::numeric_limits<uint32_t>::max() &&
+        mock.fail_image_creation_on_iteration == mock.created_image_view_count) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
     if (pView) *pView = get_uint64_handle<VkImageView>(0x0000CCCEU);
+    mock.created_image_view_count++;
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL shim_vkDestroyImageView([[maybe_unused]] VkDevice device,
     [[maybe_unused]] VkImageView imageView,
-    [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {}
+    [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {
+    if (mock.created_image_view_count == 0) {
+        throw std::runtime_error("no created image views to destroy!");
+    }
+    mock.created_image_view_count--;
+}
 
 VKAPI_ATTR void VKAPI_CALL shim_vkDestroySwapchainKHR([[maybe_unused]] VkDevice device,
     [[maybe_unused]] VkSwapchainKHR swapchain,

--- a/tests/vulkan_mock.hpp
+++ b/tests/vulkan_mock.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <limits>
 #include <memory>
 #include <utility>
 #include <stdexcept>
@@ -105,6 +106,8 @@ struct VulkanMock {
         physical_devices_details.emplace_back(std::move(details));
     }
 
+    uint32_t created_image_view_count = 0;
+    uint32_t fail_image_creation_on_iteration = std::numeric_limits<uint32_t>::max(); // max int means do not fail instance creation
     // Values set by various Vulkan API calls by the mock. Useful for checking that vk-bootstrap passed the correct
     // information "into" the API.
     // Because thread sanitizer yells when the mock writes to api_version_set_by_vkCreateInstance in


### PR DESCRIPTION
Add a simple test to ensure that all images are cleaned up. Not a perfect test, but is easy enough to verify the function was called enough times.