### PR TITLE
Rework deinitialization

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -183,15 +183,16 @@ class VulkanFunctions {
         func_dest = reinterpret_cast<T>(reinterpret_cast<void*>(GetProcAddress(library, func_name)));
 #endif
     }
-    void close() {
+    void unload_vulkan_library() {
+        if (!library) {
+            return;
+        }
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         dlclose(library);
 #elif defined(_WIN32)
         FreeLibrary(library);
 #endif
         library = 0;
-        initialized = false;
-        instance_functions_initialized = false;
     }
 
     public:

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -284,6 +284,22 @@ class VulkanFunctions {
         get_inst_proc_addr(fp_vkGetPhysicalDeviceSurfaceCapabilitiesKHR, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
         instance_functions_initialized = true;
     }
+
+    void deinit_all() {
+        {
+            std::lock_guard<std::mutex> lg(instance_functions_mutex);
+            if (instance_functions_initialized) {
+                instance_functions_initialized = false;
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lg(init_mutex);
+            if (initialized) {
+                unload_vulkan_library();
+                initialized = false;
+            }
+        }
+    }
 };
 
 static VulkanFunctions& vulkan_functions() {

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -192,7 +192,7 @@ class VulkanFunctions {
 #elif defined(_WIN32)
         FreeLibrary(library);
 #endif
-        library = 0;
+        library = nullptr;
     }
 
     public:

--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -219,7 +219,6 @@ class VulkanFunctions {
         return true;
     }
 
-    public:
     template <typename T> void get_inst_proc_addr(T& out_ptr, const char* func_name) {
         out_ptr = reinterpret_cast<T>(ptr_vkGetInstanceProcAddr(instance, func_name));
     }


### PR DESCRIPTION
Addresses https://github.com/charles-lunarg/vk-bootstrap/issues/419.

I let mutexes live in their scopes at `deinit_all` to prevent any possible deadlock scenario.