### PR TITLE
Make order of platforms in comments correct and aligned with InstanceBuilder::build()

### DIFF
--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -327,16 +327,16 @@ void destroy_instance(Instance const& instance); // release instance resources
 
 #if defined(_WIN32)
     VK_KHR_win32_surface
+#elif defined(__ANDROID__)
+    VK_KHR_android_surface
+#elif defined(_DIRECT2DISPLAY)
+    VK_KHR_display
 #elif defined(__linux__) || defined(__FreeBSD__)
     VK_KHR_xcb_surface
     VK_KHR_xlib_surface
     VK_KHR_wayland_surface
 #elif defined(__APPLE__)
     VK_EXT_metal_surface
-#elif defined(__ANDROID__)
-    VK_KHR_android_surface
-#elif defined(_DIRECT2DISPLAY)
-    VK_KHR_display
 #endif
 
 Use `InstanceBuilder::enable_extension()` to add new extensions without altering the default behavior


### PR DESCRIPTION
Here in `src/VkBootstrap.h`

```
/* If headless mode is false, by default vk-bootstrap use the following logic to enable the windowing extensions

#if defined(_WIN32)
    VK_KHR_win32_surface
#elif defined(__linux__) || defined(__FreeBSD__)
    VK_KHR_xcb_surface
    VK_KHR_xlib_surface
    VK_KHR_wayland_surface
#elif defined(__APPLE__)
    VK_EXT_metal_surface
#elif defined(__ANDROID__)
    VK_KHR_android_surface
#elif defined(_DIRECT2DISPLAY)
    VK_KHR_display
#endif

Use `InstanceBuilder::enable_extension()` to add new extensions without altering the default behavior
Feel free to make a PR or raise an issue to include additional platforms.
*/
```

I spotted that `__linux__` is checked before `__ANDROID__`. I expect that `__linux__` is defined on Android. So `__ANDROID__` should be checked before `__linux__`. Otherwise, `__ANDROID__` check is not reached on Android.

While in `InstanceBuilder::build()` in `src/VkBootstrap.cpp` the order of platforms is correct:

```
#if defined(_WIN32)
        bool added_window_exts = check_add_window_ext("VK_KHR_win32_surface");
#elif defined(__ANDROID__)
        bool added_window_exts = check_add_window_ext("VK_KHR_android_surface");
#elif defined(_DIRECT2DISPLAY)
        bool added_window_exts = check_add_window_ext("VK_KHR_display");
#elif defined(__linux__) || defined(__FreeBSD__)
        // make sure all three calls to check_add_window_ext, don't allow short circuiting
        bool added_window_exts = check_add_window_ext("VK_KHR_xcb_surface");
        added_window_exts = check_add_window_ext("VK_KHR_xlib_surface") || added_window_exts;
        added_window_exts = check_add_window_ext("VK_KHR_wayland_surface") || added_window_exts;
#elif defined(__APPLE__)
        bool added_window_exts = check_add_window_ext("VK_EXT_metal_surface");
#endif
```

So I made the order of platforms in comments aligned with what it is in `InstanceBuilder::build()`.