### PR TITLE
Fixed SwapchainBuilder constructor typo

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1875,8 +1875,8 @@ SwapchainBuilder::SwapchainBuilder(Device const& device) {
     auto present = device.get_queue_index(QueueType::present);
     auto graphics = device.get_queue_index(QueueType::graphics);
     assert(graphics.has_value() && present.has_value() && "Graphics and Present queue indexes must be valid");
-    info.graphics_queue_index = present.value();
-    info.present_queue_index = graphics.value();
+    info.graphics_queue_index = graphics.value();
+    info.present_queue_index = present.value();
 }
 SwapchainBuilder::SwapchainBuilder(Device const& device, VkSurfaceKHR const surface) {
     info.physical_device = device.physical_device.physical_device;


### PR DESCRIPTION
Hello, reviewing the code I saw in SwapchainBuilder constructor, where present.value() and graphics.value() are swapped. This code is from main

```
SwapchainBuilder::SwapchainBuilder(Device const& device) {
    info.physical_device = device.physical_device.physical_device;
    info.device = device.device;
    info.surface = device.surface;
    info.instance_version = device.instance_version;
    auto present = device.get_queue_index(QueueType::present);
    auto graphics = device.get_queue_index(QueueType::graphics);
    assert(graphics.has_value() && present.has_value() && "Graphics and Present queue indexes must be valid");
    info.graphics_queue_index = present.value();
    info.present_queue_index = graphics.value();
}
```

This pull requests just swaps it