### PR TITLE
Fix DeviceBuilder::add_pNext() dropping pNext chain elements

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -138,6 +138,16 @@ std::vector<vkb::detail::FeaturesChain::StructInfo>::const_iterator FeaturesChai
     });
 }
 
+void add_all_pnext_structures(std::vector<void*>& pNext_chain, void* structure_to_add) {
+    auto pNext_iter = structure_to_add;
+    while (pNext_iter != nullptr) {
+        pNext_chain.push_back(pNext_iter);
+        VkBaseOutStructure out_structure{};
+        memcpy(&out_structure, pNext_iter, sizeof(VkBaseOutStructure));
+        pNext_iter = out_structure.pNext;
+    }
+}
+
 
 class VulkanFunctions {
     private:
@@ -455,6 +465,17 @@ template <typename T> void setup_pNext_chain(T& structure, std::vector<void*> co
     structure.pNext = nullptr;
     if (structs.empty()) return;
     for (size_t i = 0; i < structs.size() - 1; i++) {
+        // Make sure we aren't adding the same struct more than once. We do not care about duplicate sTypes here.
+        bool is_duplicate = false;
+        for (size_t j = 0; j != i; j++) {
+            if (structs.at(i) == structs.at(j)) {
+                is_duplicate = true;
+                break;
+            }
+        }
+        if (is_duplicate) {
+            continue;
+        }
         VkBaseOutStructure out_structure{};
         memcpy(&out_structure, structs.at(i), sizeof(VkBaseOutStructure));
 #if !defined(NDEBUG)
@@ -1713,8 +1734,8 @@ Result<Device> DeviceBuilder::build() const {
         }
     }
 
-    for (auto& pnext : info.pNext_chain) {
-        final_pnext_chain.push_back(pnext);
+    for (auto& pNext : info.pNext_chain) {
+        final_pnext_chain.push_back(pNext);
     }
 
     detail::setup_pNext_chain(device_create_info, final_pnext_chain);
@@ -1766,6 +1787,10 @@ DeviceBuilder& DeviceBuilder::custom_queue_setup(std::span<const CustomQueueDesc
     return *this;
 }
 #endif
+DeviceBuilder& DeviceBuilder::add_pNext(void* structure_to_add) {
+    detail::add_all_pnext_structures(info.pNext_chain, structure_to_add);
+    return *this;
+}
 
 // ---- Swapchain ---- //
 
@@ -2166,6 +2191,10 @@ SwapchainBuilder& SwapchainBuilder::use_default_present_mode_selection() {
 }
 SwapchainBuilder& SwapchainBuilder::set_allocation_callbacks(VkAllocationCallbacks* callbacks) {
     info.allocation_callbacks = callbacks;
+    return *this;
+}
+SwapchainBuilder& SwapchainBuilder::add_pNext(void* structure_to_add) {
+    detail::add_all_pnext_structures(info.pNext_chain, structure_to_add);
     return *this;
 }
 SwapchainBuilder& SwapchainBuilder::set_image_usage_flags(VkImageUsageFlags usage_flags) {

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -820,12 +820,11 @@ class DeviceBuilder {
     DeviceBuilder& custom_queue_setup(std::span<const CustomQueueDescription> queue_descriptions);
 #endif
 
-    // Add a structure to the pNext chain of VkDeviceCreateInfo.
+    // Add a pNext chain structure to the pNext chain of VkDeviceCreateInfo.
     // The structure must be valid when DeviceBuilder::build() is called.
-    template <typename T> DeviceBuilder& add_pNext(T* structure) {
-        info.pNext_chain.push_back(structure);
-        return *this;
-    }
+    // The structure must be a type that is valid to add to the pNext chain of VkDeviceCreateInfo
+    // Any structures chained through the pNext pointer will also be added
+    DeviceBuilder& add_pNext(void* structure_to_add);
 
     // Provide custom allocation callbacks.
     DeviceBuilder& set_allocation_callbacks(VkAllocationCallbacks* callbacks);
@@ -978,10 +977,9 @@ class SwapchainBuilder {
 
     // Add a structure to the pNext chain of VkSwapchainCreateInfoKHR.
     // The structure must be valid when SwapchainBuilder::build() is called.
-    template <typename T> SwapchainBuilder& add_pNext(T* structure) {
-        info.pNext_chain.push_back(structure);
-        return *this;
-    }
+    // The structure must be a type that is valid to add to the pNext chain of VkSwapchainCreateInfoKHR
+    // Any structures chained through the pNext pointer will also be added
+    SwapchainBuilder& add_pNext(void* structure_to_add);
 
     // Provide custom allocation callbacks.
     SwapchainBuilder& set_allocation_callbacks(VkAllocationCallbacks* callbacks);

--- a/tests/bootstrap_tests.cpp
+++ b/tests/bootstrap_tests.cpp
@@ -195,12 +195,25 @@ TEST_CASE("Device Configuration", "[VkBootstrap.bootstrap]") {
     }
 
     SECTION("VkPhysicalDeviceFeatures2 in pNext Chain") {
+        VkPhysicalDeviceMultiviewFeatures multiview_features{};
+        multiview_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
+
         VkPhysicalDeviceShaderDrawParameterFeatures shader_draw_features{};
         shader_draw_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES;
+        shader_draw_features.pNext = &multiview_features;
 
         vkb::DeviceBuilder device_builder(phys_device_ret.value());
         auto device_ret = device_builder.add_pNext(&shader_draw_features).build();
         REQUIRE(device_ret.has_value());
+
+        // Check that the pNext chain was passed through successfully
+        auto& features_pNextChain = mock.physical_devices_details.at(0).created_device_details.at(0).features_pNextChain;
+        auto* s1 = reinterpret_cast<VkPhysicalDeviceShaderDrawParameterFeatures*>(features_pNextChain.at(0).data());
+        auto* s2 = reinterpret_cast<VkPhysicalDeviceMultiviewFeatures*>(features_pNextChain.at(1).data());
+
+        REQUIRE(s1->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES);
+        REQUIRE(s2->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES);
+
         vkb::destroy_device(device_ret.value());
     }
 

--- a/tests/vulkan_mock.hpp
+++ b/tests/vulkan_mock.hpp
@@ -36,6 +36,10 @@ inline SerializedStruct create_serialized_struct_from_features2_struct(const voi
             return create_serialized_struct_from_object(*static_cast<const VkPhysicalDeviceVulkan12Features*>(input_data));
         case (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES):
             return create_serialized_struct_from_object(*static_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(input_data));
+        case (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES):
+            return create_serialized_struct_from_object(*static_cast<const VkPhysicalDeviceMultiviewFeatures*>(input_data));
+        case (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES):
+            return create_serialized_struct_from_object(*static_cast<const VkPhysicalDeviceShaderDrawParameterFeatures*>(input_data));
         default:
             return SerializedStruct{};
     }


### PR DESCRIPTION
When a user provides a pNext chain to DeviceBuilder::add_pNext(), vk-bootstrap did not look at the pNext chain of the passed in struct, leaving to missing elements. While the library could require that each struct must be passed in explicitly with DeviceBuilder::add_pNext(), it isn't difficult to iterate the passed in pNext chain and grab the pointers to the structs to build the final pNext chain with.

This commit also adds deduplication to building of the final pNext chain so that the same struct (as in, same memory address, it doesn't take sTypes into consideration) isn't in the chain more than once.

Fixes #478 