### PR TITLE
Add Swapchain::get_images_and_image_views helper function

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -2087,9 +2087,17 @@ Result<std::vector<VkImage>> Swapchain::get_images() {
 }
 Result<std::vector<VkImageView>> Swapchain::get_image_views() { return get_image_views(nullptr); }
 Result<std::vector<VkImageView>> Swapchain::get_image_views(const void* pNext) {
-    const auto swapchain_images_ret = get_images();
+    auto images_and_image_views_ret = get_images_and_image_views(pNext);
+    if (!images_and_image_views_ret) return { images_and_image_views_ret.error() };
+    return std::move(images_and_image_views_ret.value().second);
+}
+Result<std::pair<std::vector<VkImage>, std::vector<VkImageView>>> Swapchain::get_images_and_image_views() {
+    return get_images_and_image_views(nullptr);
+}
+Result<std::pair<std::vector<VkImage>, std::vector<VkImageView>>> Swapchain::get_images_and_image_views(const void* pNext) {
+    auto swapchain_images_ret = get_images();
     if (!swapchain_images_ret) return swapchain_images_ret.error();
-    const auto& swapchain_images = swapchain_images_ret.value();
+    auto& swapchain_images = swapchain_images_ret.value();
 
     bool already_contains_image_view_usage = false;
     const void* pNext_iter = pNext;
@@ -2133,10 +2141,11 @@ Result<std::vector<VkImageView>> Swapchain::get_image_views(const void* pNext) {
         if (res != VK_SUCCESS) {
             // Cleanup already created image views
             destroy_image_views(i, views.data());
-            return Result<std::vector<VkImageView>>{ SwapchainError::failed_create_swapchain_image_views, res };
+            return Result<std::pair<std::vector<VkImage>, std::vector<VkImageView>>>{ SwapchainError::failed_create_swapchain_image_views,
+                res };
         }
     }
-    return views;
+    return std::pair{ std::move(swapchain_images), std::move(views) };
 }
 void Swapchain::destroy_image_views(size_t count, VkImageView const* image_views) {
     for (size_t i = 0; i < count; ++i) {

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -862,6 +862,12 @@ struct Swapchain {
     // structure.
     Result<std::vector<VkImageView>> get_image_views();
     Result<std::vector<VkImageView>> get_image_views(const void* pNext);
+
+    // Returns both a vector of VkImage handles to the swapchain and a vector of VkImageViews to said VkImages.
+    // VkImageViews must be destroyed. The pNext chain must be a nullptr or a valid structure.
+    Result<std::pair<std::vector<VkImage>, std::vector<VkImageView>>> get_images_and_image_views();
+    Result<std::pair<std::vector<VkImage>, std::vector<VkImageView>>> get_images_and_image_views(const void* pNext);
+
     void destroy_image_views(size_t count, VkImageView const* image_views);
     void destroy_image_views(std::vector<VkImageView> const& image_views);
 #if VKB_SPAN_OVERLOADS


### PR DESCRIPTION
Adds `Swapchain::get_images_and_image_views()`, which returns both the images and their image views as a `std::pair` for convenience and avoids the redundant call to `get_images()` when both are needed.

Mirrors the existing `get_image_views()` overloads (with and without a pNext chain) and follows the pattern of `Device::get_queue_and_index` from #463.

Closes #484