### PR TITLE
Add uint32 overload to PhysicalDeviceSelector::set_minimum_version

### DIFF
--- a/src/VkBootstrap.cpp
+++ b/src/VkBootstrap.cpp
@@ -1440,6 +1440,10 @@ PhysicalDeviceSelector& PhysicalDeviceSelector::set_minimum_version(uint32_t maj
     criteria.required_version = VKB_MAKE_VK_VERSION(0, major, minor, 0);
     return *this;
 }
+PhysicalDeviceSelector& PhysicalDeviceSelector::set_minimum_version(uint32_t minimum_api_version) {
+    criteria.required_version = minimum_api_version;
+    return *this;
+}
 PhysicalDeviceSelector& PhysicalDeviceSelector::disable_portability_subset() {
     criteria.enable_portability_subset = false;
     return *this;

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -652,7 +652,7 @@ class PhysicalDeviceSelector {
     // Require a physical device that supports a (major, minor) version of vulkan.
     PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);
     // Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
-    PhysicalDeviceSelector& PhysicalDeviceSelector::set_minimum_version(uint32_t minimum_api_version);
+    PhysicalDeviceSelector& set_minimum_version(uint32_t minimum_api_version);
 
     // By default PhysicalDeviceSelector enables the portability subset if available
     // This function disables that behavior

--- a/src/VkBootstrap.h
+++ b/src/VkBootstrap.h
@@ -651,6 +651,8 @@ class PhysicalDeviceSelector {
 
     // Require a physical device that supports a (major, minor) version of vulkan.
     PhysicalDeviceSelector& set_minimum_version(uint32_t major, uint32_t minor);
+    // Should be constructed with VK_MAKE_VERSION or VK_MAKE_API_VERSION.
+    PhysicalDeviceSelector& PhysicalDeviceSelector::set_minimum_version(uint32_t minimum_api_version);
 
     // By default PhysicalDeviceSelector enables the portability subset if available
     // This function disables that behavior


### PR DESCRIPTION
This allows for usage of Vulkan version macros, similar to InstanceBuilder::require_api_version